### PR TITLE
Improve mobile layout for project tabs (data sources, components)

### DIFF
--- a/src/Deckle.Web/src/lib/components/TabContent.svelte
+++ b/src/Deckle.Web/src/lib/components/TabContent.svelte
@@ -32,5 +32,6 @@
     gap: 0.75rem;
     margin-bottom: 1.5rem;
     width: 100%;
+    flex-wrap: wrap;
   }
 </style>

--- a/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/+layout.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/+layout.svelte
@@ -73,6 +73,13 @@
     display: flex;
     flex-direction: column;
   }
+
+  @media (max-width: 640px) {
+    .project-page-content {
+      padding: 1rem;
+    }
+  }
+
   .project-page-content.nopadding {
     padding: 0;
   }

--- a/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/components/+page.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/components/+page.svelte
@@ -119,7 +119,7 @@
 <TabContent>
   {#snippet actions()}
     {#if canEdit || hasExportableComponents}
-      <div>
+      <div class="actions-group">
         {#if hasExportableComponents}
           <Button variant="secondary" size="sm" onclick={navigateToExport}>Export</Button>
         {/if}
@@ -183,9 +183,14 @@
 />
 
 <style>
+  .actions-group {
+    display: flex;
+    gap: 0.5rem;
+  }
+
   .components-list {
     display: grid;
-    grid-template-columns: repeat(auto-fill, minmax(350px, 1fr));
+    grid-template-columns: repeat(auto-fill, minmax(min(350px, 100%), 1fr));
     gap: 1rem;
   }
 </style>

--- a/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/data-sources/+page.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/data-sources/+page.svelte
@@ -411,6 +411,19 @@
     display: flex;
     justify-content: space-between;
     align-items: center;
+    gap: 1rem;
+  }
+
+  @media (max-width: 600px) {
+    .card-content {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 0.75rem;
+    }
+
+    .source-actions {
+      flex-wrap: wrap;
+    }
   }
 
   .source-info h3 {


### PR DESCRIPTION
- Data sources cards: stack info and actions vertically below 600px instead of
  squishing info into a narrow left column with buttons floating right
- Components grid: use min(350px, 100%) so cards never overflow on narrow screens
- Components actions: add gap between Export and Add Component buttons
- Project layout: reduce padding from 2rem to 1rem on mobile (<=640px)
- TabContent: add flex-wrap to the actions row so buttons wrap cleanly on small screens

https://claude.ai/code/session_01Kmc7JFQKgB1gR6xLqxaEeL