### PR TITLE
Add MCP server for AI agent project management

### DIFF
--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -202,14 +202,18 @@ jobs:
 
       - name: Trigger Railway Deployment
         if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        env:
+          RAILWAY_API_WEBHOOK_URL: ${{ secrets.RAILWAY_API_WEBHOOK_URL }}
+          RAILWAY_WEB_WEBHOOK_URL: ${{ secrets.RAILWAY_WEB_WEBHOOK_URL }}
+          RAILWAY_MCP_WEBHOOK_URL: ${{ secrets.RAILWAY_MCP_WEBHOOK_URL }}
         run: |
           echo "Triggering Railway API deployment..."
-          curl -f -X POST "${{ secrets.RAILWAY_API_WEBHOOK_URL }}" || echo "Warning: API webhook failed"
+          curl -f -X POST "$RAILWAY_API_WEBHOOK_URL" || echo "Warning: API webhook failed"
 
           echo "Triggering Railway Web deployment..."
-          curl -f -X POST "${{ secrets.RAILWAY_WEB_WEBHOOK_URL }}" || echo "Warning: Web webhook failed"
+          curl -f -X POST "$RAILWAY_WEB_WEBHOOK_URL" || echo "Warning: Web webhook failed"
 
           echo "Triggering Railway MCP deployment..."
-          curl -f -X POST "${{ secrets.RAILWAY_MCP_WEBHOOK_URL }}" || echo "Warning: MCP webhook failed"
+          curl -f -X POST "$RAILWAY_MCP_WEBHOOK_URL" || echo "Warning: MCP webhook failed"
 
           echo "Railway deployments triggered successfully"

--- a/.github/workflows/build-and-deploy.yml
+++ b/.github/workflows/build-and-deploy.yml
@@ -93,11 +93,16 @@ jobs:
           cd src/Deckle.Web
           docker build -t deckle-web:local .
 
+      - name: Build MCP container
+        run: |
+          cd src
+          docker build -f Deckle.MCP/Dockerfile -t deckle-mcp:local .
+
       - name: Prepare docker-compose artifacts
         run: |
           # Copy template and replace environment variables with actual image names
           cp docker-compose-artifacts/docker-compose.yaml docker-compose-artifacts/docker-compose.yaml.template
-          sed 's/\${API_IMAGE}/deckle-api:local/g; s/\${WEB_IMAGE}/deckle-web:local/g' docker-compose-artifacts/docker-compose.yaml.template > docker-compose-artifacts/docker-compose.yaml
+          sed 's/\${API_IMAGE}/deckle-api:local/g; s/\${WEB_IMAGE}/deckle-web:local/g; s/\${MCP_IMAGE}/deckle-mcp:local/g' docker-compose-artifacts/docker-compose.yaml.template > docker-compose-artifacts/docker-compose.yaml
 
       - name: Log in to GitHub Container Registry
         if: github.event_name != 'pull_request'
@@ -203,5 +208,8 @@ jobs:
 
           echo "Triggering Railway Web deployment..."
           curl -f -X POST "${{ secrets.RAILWAY_WEB_WEBHOOK_URL }}" || echo "Warning: Web webhook failed"
+
+          echo "Triggering Railway MCP deployment..."
+          curl -f -X POST "${{ secrets.RAILWAY_MCP_WEBHOOK_URL }}" || echo "Warning: MCP webhook failed"
 
           echo "Railway deployments triggered successfully"

--- a/docker-compose-artifacts/docker-compose.yaml
+++ b/docker-compose-artifacts/docker-compose.yaml
@@ -70,6 +70,31 @@ services:
         condition: "service_started"
     networks:
       - "aspire"
+  mcp:
+    image: "${MCP_IMAGE}"
+    environment:
+      OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EXCEPTION_LOG_ATTRIBUTES: "true"
+      OTEL_DOTNET_EXPERIMENTAL_OTLP_EMIT_EVENT_LOG_ATTRIBUTES: "true"
+      OTEL_DOTNET_EXPERIMENTAL_OTLP_RETRY: "in_memory"
+      ASPNETCORE_FORWARDEDHEADERS_ENABLED: "true"
+      HTTP_PORTS: "${MCP_PORT}"
+      ConnectionStrings__deckledb: "Host=postgres;Port=5432;Username=postgres;Password=${POSTGRES_PASSWORD};Database=deckledb"
+      DECKLEDB_HOST: "postgres"
+      DECKLEDB_PORT: "5432"
+      DECKLEDB_USERNAME: "postgres"
+      DECKLEDB_PASSWORD: "${POSTGRES_PASSWORD}"
+      DECKLEDB_URI: "postgresql://postgres:${POSTGRES_PASSWORD}@postgres:5432/deckledb"
+      DECKLEDB_DATABASENAME: "deckledb"
+      OTEL_EXPORTER_OTLP_ENDPOINT: "http://compose-dashboard:18889"
+      OTEL_EXPORTER_OTLP_PROTOCOL: "grpc"
+      OTEL_SERVICE_NAME: "mcp"
+    expose:
+      - "${MCP_PORT}"
+    depends_on:
+      postgres:
+        condition: "service_started"
+    networks:
+      - "aspire"
 networks:
   aspire:
     driver: "bridge"

--- a/src/Deckle.API.Tests/ApiKeyEndpointsTests.cs
+++ b/src/Deckle.API.Tests/ApiKeyEndpointsTests.cs
@@ -1,0 +1,207 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.RegularExpressions;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Deckle.API.Tests;
+
+/// <summary>
+/// Verifies the key-generation invariants of the POST /api-keys handler.
+/// The handler generates: rawKey = "dk_" + base64url(32 random bytes), stores SHA256(rawKey).
+/// These tests validate those properties independently of the HTTP layer.
+/// </summary>
+public class ApiKeyEndpointsTests : IDisposable
+{
+    private bool _disposed;
+    private readonly AppDbContext _context;
+
+    public ApiKeyEndpointsTests()
+    {
+        _context = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+                _context.Dispose();
+            _disposed = true;
+        }
+    }
+
+    private static string GenerateRawKey()
+    {
+        var rawBytes = RandomNumberGenerator.GetBytes(32);
+        return "dk_" + Convert.ToBase64String(rawBytes)
+            .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+    }
+
+    private static string HashKey(string rawKey) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawKey)));
+
+    private async Task<Guid> SeedUser()
+    {
+        var userId = Guid.NewGuid();
+        _context.Users.Add(new User
+        {
+            Id = userId,
+            Email = $"{userId}@test.com",
+            GoogleId = Guid.NewGuid().ToString(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+        return userId;
+    }
+
+    #region Key generation format
+
+    [Fact]
+    public void GeneratedKey_StartsWithDkPrefix()
+    {
+        var key = GenerateRawKey();
+
+        Assert.StartsWith("dk_", key);
+    }
+
+    [Fact]
+    public void GeneratedKey_ContainsNoBase64PaddingOrUnsafeChars()
+    {
+        for (var i = 0; i < 20; i++)
+        {
+            var key = GenerateRawKey();
+            Assert.DoesNotContain("+", key);
+            Assert.DoesNotContain("/", key);
+            Assert.DoesNotContain("=", key);
+        }
+    }
+
+    [Fact]
+    public void GeneratedKey_IsUrlSafe()
+    {
+        var key = GenerateRawKey();
+
+        Assert.Matches(new Regex(@"^dk_[A-Za-z0-9\-_]+$"), key);
+    }
+
+    [Fact]
+    public void GeneratedKeys_AreUnique()
+    {
+        var keys = Enumerable.Range(0, 50).Select(_ => GenerateRawKey()).ToList();
+
+        Assert.Equal(keys.Count, keys.Distinct().Count());
+    }
+
+    #endregion
+
+    #region Key hashing invariants
+
+    [Fact]
+    public void StoredHash_IsSha256HexOfRawKey()
+    {
+        var rawKey = GenerateRawKey();
+
+        var hash = HashKey(rawKey);
+
+        Assert.Equal(64, hash.Length);
+        Assert.Matches(new Regex("^[0-9A-F]{64}$"), hash);
+    }
+
+    [Fact]
+    public void StoredHash_DifferentFromRawKey()
+    {
+        var rawKey = GenerateRawKey();
+
+        Assert.NotEqual(rawKey, HashKey(rawKey));
+    }
+
+    [Fact]
+    public void StoredHash_IsDeterministicForSameInput()
+    {
+        var rawKey = GenerateRawKey();
+
+        Assert.Equal(HashKey(rawKey), HashKey(rawKey));
+    }
+
+    [Fact]
+    public void StoredHash_DifferentForDifferentKeys()
+    {
+        var key1 = GenerateRawKey();
+        var key2 = GenerateRawKey();
+
+        Assert.NotEqual(HashKey(key1), HashKey(key2));
+    }
+
+    #endregion
+
+    #region User scoping (database-level)
+
+    [Fact]
+    public async Task ApiKey_StoredWithCorrectUserId()
+    {
+        var userId = await SeedUser();
+        var rawKey = GenerateRawKey();
+        _context.ApiKeys.Add(new ApiKey
+        {
+            Id = Guid.NewGuid(),
+            UserId = userId,
+            Name = "My Key",
+            KeyHash = HashKey(rawKey),
+            CreatedAt = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+
+        _context.ChangeTracker.Clear();
+        var stored = await _context.ApiKeys.FirstAsync(k => k.UserId == userId);
+        Assert.Equal("My Key", stored.Name);
+        Assert.Equal(HashKey(rawKey), stored.KeyHash);
+    }
+
+    [Fact]
+    public async Task ListApiKeys_ReturnsOnlyOwnersKeys()
+    {
+        var userId1 = await SeedUser();
+        var userId2 = await SeedUser();
+
+        _context.ApiKeys.AddRange(
+            new ApiKey { Id = Guid.NewGuid(), UserId = userId1, Name = "Key A", KeyHash = HashKey("dk_a"), CreatedAt = DateTime.UtcNow },
+            new ApiKey { Id = Guid.NewGuid(), UserId = userId2, Name = "Key B", KeyHash = HashKey("dk_b"), CreatedAt = DateTime.UtcNow });
+        await _context.SaveChangesAsync();
+
+        var user1Keys = await _context.ApiKeys.Where(k => k.UserId == userId1).ToListAsync();
+        Assert.Single(user1Keys);
+        Assert.Equal("Key A", user1Keys[0].Name);
+    }
+
+    [Fact]
+    public async Task DeleteApiKey_OnlyDeletesOwnersKey()
+    {
+        var userId1 = await SeedUser();
+        var userId2 = await SeedUser();
+        var keyId = Guid.NewGuid();
+
+        _context.ApiKeys.AddRange(
+            new ApiKey { Id = keyId, UserId = userId1, Name = "Owner Key", KeyHash = HashKey("dk_owner"), CreatedAt = DateTime.UtcNow },
+            new ApiKey { Id = Guid.NewGuid(), UserId = userId2, Name = "Other Key", KeyHash = HashKey("dk_other"), CreatedAt = DateTime.UtcNow });
+        await _context.SaveChangesAsync();
+
+        var key = await _context.ApiKeys.FirstOrDefaultAsync(k => k.Id == keyId && k.UserId == userId1);
+        Assert.NotNull(key);
+
+        var wrongUserKey = await _context.ApiKeys.FirstOrDefaultAsync(k => k.Id == keyId && k.UserId == userId2);
+        Assert.Null(wrongUserKey);
+    }
+
+    #endregion
+}

--- a/src/Deckle.API.Tests/Services/UserServiceTests.cs
+++ b/src/Deckle.API.Tests/Services/UserServiceTests.cs
@@ -2,7 +2,9 @@ using Deckle.API.DTOs;
 using Deckle.API.Services;
 using Deckle.Domain.Data;
 using Deckle.Domain.Entities;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using Moq;
 using System.Security.Claims;
 
 namespace Deckle.API.Tests.Services;
@@ -19,7 +21,8 @@ public class UserServiceTests : IDisposable
             .UseInMemoryDatabase(databaseName: Guid.NewGuid().ToString())
             .Options;
         _context = new AppDbContext(options);
-        _service = new UserService(_context);
+        var passwordHasher = new Mock<IPasswordHasher<User>>().Object;
+        _service = new UserService(_context, passwordHasher);
     }
 
     #region Helpers

--- a/src/Deckle.API/DTOs/ApiKeyDtos.cs
+++ b/src/Deckle.API/DTOs/ApiKeyDtos.cs
@@ -1,0 +1,7 @@
+namespace Deckle.API.DTOs;
+
+public record ApiKeyDto(Guid Id, string Name, DateTime CreatedAt, DateTime? LastUsedAt);
+
+public record CreateApiKeyRequest(string Name);
+
+public record CreateApiKeyResponse(Guid Id, string Name, string Key, DateTime CreatedAt);

--- a/src/Deckle.API/Endpoints/ApiKeyEndpoints.cs
+++ b/src/Deckle.API/Endpoints/ApiKeyEndpoints.cs
@@ -1,0 +1,75 @@
+using System.Security.Cryptography;
+using System.Text;
+using Deckle.API.DTOs;
+using Deckle.API.Filters;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Microsoft.EntityFrameworkCore;
+
+namespace Deckle.API.Endpoints;
+
+public static class ApiKeyEndpoints
+{
+    public static RouteGroupBuilder MapApiKeyEndpoints(this IEndpointRouteBuilder routes)
+    {
+        var group = routes.MapGroup("/api-keys")
+            .WithTags("API Keys")
+            .RequireAuthorization()
+            .RequireUserId();
+
+        group.MapGet("", async (HttpContext ctx, AppDbContext db) =>
+        {
+            var userId = ctx.GetUserId();
+            var keys = await db.ApiKeys
+                .Where(k => k.UserId == userId)
+                .OrderByDescending(k => k.CreatedAt)
+                .Select(k => new ApiKeyDto(k.Id, k.Name, k.CreatedAt, k.LastUsedAt))
+                .ToListAsync();
+            return Results.Ok(keys);
+        })
+        .WithName("ListApiKeys");
+
+        group.MapPost("", async (HttpContext ctx, AppDbContext db, CreateApiKeyRequest request) =>
+        {
+            var userId = ctx.GetUserId();
+
+            var rawBytes = RandomNumberGenerator.GetBytes(32);
+            var rawKey = "dk_" + Convert.ToBase64String(rawBytes)
+                .Replace('+', '-').Replace('/', '_').TrimEnd('=');
+
+            var keyHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawKey)));
+
+            var apiKey = new ApiKey
+            {
+                Id = Guid.NewGuid(),
+                UserId = userId,
+                Name = request.Name,
+                KeyHash = keyHash,
+                CreatedAt = DateTime.UtcNow
+            };
+
+            db.ApiKeys.Add(apiKey);
+            await db.SaveChangesAsync();
+
+            return Results.Created(
+                $"/api-keys/{apiKey.Id}",
+                new CreateApiKeyResponse(apiKey.Id, apiKey.Name, rawKey, apiKey.CreatedAt));
+        })
+        .WithName("CreateApiKey");
+
+        group.MapDelete("{id:guid}", async (Guid id, HttpContext ctx, AppDbContext db) =>
+        {
+            var userId = ctx.GetUserId();
+            var key = await db.ApiKeys.FirstOrDefaultAsync(k => k.Id == id && k.UserId == userId);
+            if (key == null)
+                return Results.NotFound();
+
+            db.ApiKeys.Remove(key);
+            await db.SaveChangesAsync();
+            return Results.NoContent();
+        })
+        .WithName("DeleteApiKey");
+
+        return group;
+    }
+}

--- a/src/Deckle.API/Extensions/WebApplicationExtensions.cs
+++ b/src/Deckle.API/Extensions/WebApplicationExtensions.cs
@@ -73,6 +73,7 @@ public static class WebApplicationExtensions
         app.MapFileDirectoryEndpoints();
         app.MapAdminEndpoints();
         app.MapUserEndpoints();
+        app.MapApiKeyEndpoints();
 
         return app;
     }

--- a/src/Deckle.AppHost/AppHost.cs
+++ b/src/Deckle.AppHost/AppHost.cs
@@ -38,6 +38,14 @@ var api = builder.AddProject<Projects.Deckle_API>("api")
         service.Name = "api";
     });
 
+var mcp = builder.AddProject<Projects.Deckle_MCP>("mcp")
+    .WithReference(database)
+    .WaitFor(database)
+    .PublishAsDockerComposeService((resource, service) =>
+    {
+        service.Name = "mcp";
+    });
+
 web.WithReference(api)
     .WithEnvironment("PUBLIC_API_URL", api.GetEndpoint("http"));
 

--- a/src/Deckle.AppHost/Deckle.AppHost.csproj
+++ b/src/Deckle.AppHost/Deckle.AppHost.csproj
@@ -16,6 +16,7 @@
 
   <ItemGroup>
     <ProjectReference Include="..\Deckle.API\Deckle.API.csproj" />
+    <ProjectReference Include="..\Deckle.MCP\Deckle.MCP.csproj" />
   </ItemGroup>
 
 </Project>

--- a/src/Deckle.Domain/Data/AppDbContext.cs
+++ b/src/Deckle.Domain/Data/AppDbContext.cs
@@ -12,6 +12,7 @@ public class AppDbContext : DbContext
     }
 
     public DbSet<User> Users { get; set; }
+    public DbSet<ApiKey> ApiKeys { get; set; }
     public DbSet<Project> Projects { get; set; }
     public DbSet<UserProject> UserProjects { get; set; }
     public DbSet<DataSource> DataSources { get; set; }
@@ -99,6 +100,31 @@ public class AppDbContext : DbContext
                 .IsRequired()
                 .HasConversion<string>()
                 .HasDefaultValue(UserRole.User);
+        });
+
+        modelBuilder.Entity<ApiKey>(entity =>
+        {
+            entity.HasKey(ak => ak.Id);
+
+            entity.Property(ak => ak.Name)
+                .IsRequired()
+                .HasMaxLength(255);
+
+            entity.Property(ak => ak.KeyHash)
+                .IsRequired()
+                .HasMaxLength(500);
+
+            entity.Property(ak => ak.CreatedAt)
+                .IsRequired()
+                .HasDefaultValueSql("CURRENT_TIMESTAMP");
+
+            entity.HasOne(ak => ak.User)
+                .WithMany(u => u.ApiKeys)
+                .HasForeignKey(ak => ak.UserId)
+                .OnDelete(DeleteBehavior.Cascade);
+
+            entity.HasIndex(ak => ak.KeyHash).IsUnique();
+            entity.HasIndex(ak => ak.UserId);
         });
 
         modelBuilder.Entity<Project>(entity =>

--- a/src/Deckle.Domain/Entities/ApiKey.cs
+++ b/src/Deckle.Domain/Entities/ApiKey.cs
@@ -1,0 +1,12 @@
+namespace Deckle.Domain.Entities;
+
+public class ApiKey
+{
+    public Guid Id { get; set; }
+    public Guid UserId { get; set; }
+    public User User { get; set; } = null!;
+    public string Name { get; set; } = string.Empty;
+    public string KeyHash { get; set; } = string.Empty;
+    public DateTime? LastUsedAt { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/src/Deckle.Domain/Entities/User.cs
+++ b/src/Deckle.Domain/Entities/User.cs
@@ -41,4 +41,5 @@ public class User
     public ICollection<Project> Projects { get; set; } = [];
     public ICollection<UserProject> UserProjects { get; set; } = [];
     public ICollection<File> UploadedFiles { get; set; } = [];
+    public ICollection<ApiKey> ApiKeys { get; set; } = [];
 }

--- a/src/Deckle.Domain/Migrations/20260510135726_AddApiKeys.Designer.cs
+++ b/src/Deckle.Domain/Migrations/20260510135726_AddApiKeys.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Deckle.Domain.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 
@@ -11,9 +12,11 @@ using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 namespace Deckle.Domain.Migrations
 {
     [DbContext(typeof(AppDbContext))]
-    partial class AppDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260510135726_AddApiKeys")]
+    partial class AddApiKeys
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/Deckle.Domain/Migrations/20260510135726_AddApiKeys.cs
+++ b/src/Deckle.Domain/Migrations/20260510135726_AddApiKeys.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace Deckle.Domain.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddApiKeys : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ApiKeys",
+                columns: table => new
+                {
+                    Id = table.Column<Guid>(type: "uuid", nullable: false),
+                    UserId = table.Column<Guid>(type: "uuid", nullable: false),
+                    Name = table.Column<string>(type: "character varying(255)", maxLength: 255, nullable: false),
+                    KeyHash = table.Column<string>(type: "character varying(500)", maxLength: 500, nullable: false),
+                    LastUsedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "timestamp with time zone", nullable: false, defaultValueSql: "CURRENT_TIMESTAMP")
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ApiKeys", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ApiKeys_Users_UserId",
+                        column: x => x.UserId,
+                        principalTable: "Users",
+                        principalColumn: "Id",
+                        onDelete: ReferentialAction.Cascade);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiKeys_KeyHash",
+                table: "ApiKeys",
+                column: "KeyHash",
+                unique: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ApiKeys_UserId",
+                table: "ApiKeys",
+                column: "UserId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ApiKeys");
+        }
+    }
+}

--- a/src/Deckle.MCP.Tests/Auth/ApiKeyAuthenticationHandlerTests.cs
+++ b/src/Deckle.MCP.Tests/Auth/ApiKeyAuthenticationHandlerTests.cs
@@ -1,0 +1,222 @@
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Deckle.MCP.Auth;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging.Abstractions;
+using Microsoft.Extensions.Options;
+using Moq;
+
+namespace Deckle.MCP.Tests.Auth;
+
+public class ApiKeyAuthenticationHandlerTests : IDisposable
+{
+    private bool _disposed;
+    private readonly AppDbContext _context;
+
+    public ApiKeyAuthenticationHandlerTests()
+    {
+        _context = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+                _context.Dispose();
+            _disposed = true;
+        }
+    }
+
+    private async Task<ApiKeyAuthenticationHandler> CreateHandlerAsync(DefaultHttpContext httpContext)
+    {
+        var optionsMock = new Mock<IOptionsMonitor<AuthenticationSchemeOptions>>();
+        optionsMock.Setup(o => o.Get(ApiKeyAuthenticationHandler.SchemeName))
+            .Returns(new AuthenticationSchemeOptions());
+
+        var handler = new ApiKeyAuthenticationHandler(
+            optionsMock.Object,
+            new NullLoggerFactory(),
+            UrlEncoder.Default,
+            _context);
+
+        var scheme = new AuthenticationScheme(
+            ApiKeyAuthenticationHandler.SchemeName,
+            null,
+            typeof(ApiKeyAuthenticationHandler));
+
+        await handler.InitializeAsync(scheme, httpContext);
+        return handler;
+    }
+
+    private static string HashKey(string rawKey) =>
+        Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawKey)));
+
+    private async Task<(User user, string rawKey)> SeedUserWithApiKey(
+        string email = "user@test.com",
+        string username = "testuser",
+        string rawKey = "dk_testkey123")
+    {
+        var user = new User
+        {
+            Id = Guid.NewGuid(),
+            Email = email,
+            Username = username,
+            GoogleId = Guid.NewGuid().ToString(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        _context.Users.Add(user);
+        _context.ApiKeys.Add(new ApiKey
+        {
+            Id = Guid.NewGuid(),
+            UserId = user.Id,
+            Name = "Test Key",
+            KeyHash = HashKey(rawKey),
+            CreatedAt = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+        return (user, rawKey);
+    }
+
+    #region Missing / invalid header
+
+    [Fact]
+    public async Task HandleAuthenticate_MissingHeader_ReturnsFail()
+    {
+        var httpContext = new DefaultHttpContext();
+        var handler = await CreateHandlerAsync(httpContext);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("Missing", result.Failure!.Message);
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_EmptyHeader_ReturnsFail()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = "   ";
+        var handler = await CreateHandlerAsync(httpContext);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("Empty", result.Failure!.Message);
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_KeyNotInDatabase_ReturnsFail()
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = "dk_nosuchkey";
+        var handler = await CreateHandlerAsync(httpContext);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.False(result.Succeeded);
+        Assert.Contains("Invalid", result.Failure!.Message);
+    }
+
+    #endregion
+
+    #region Valid key
+
+    [Fact]
+    public async Task HandleAuthenticate_ValidKey_ReturnsSuccess()
+    {
+        var (_, rawKey) = await SeedUserWithApiKey();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = rawKey;
+        var handler = await CreateHandlerAsync(httpContext);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.True(result.Succeeded);
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_ValidKey_PrincipalHasUserIdClaim()
+    {
+        var (user, rawKey) = await SeedUserWithApiKey();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = rawKey;
+        var handler = await CreateHandlerAsync(httpContext);
+
+        var result = await handler.AuthenticateAsync();
+
+        var userIdClaim = result.Principal!.FindFirst("user_id")?.Value;
+        Assert.Equal(user.Id.ToString(), userIdClaim);
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_ValidKey_PrincipalHasEmailClaim()
+    {
+        var (user, rawKey) = await SeedUserWithApiKey(email: "alice@example.com");
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = rawKey;
+        var handler = await CreateHandlerAsync(httpContext);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.Equal("alice@example.com", result.Principal!.FindFirst(System.Security.Claims.ClaimTypes.Email)?.Value);
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_ValidKey_PrincipalHasUsernameClaim()
+    {
+        var (_, rawKey) = await SeedUserWithApiKey(username: "jdoe");
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = rawKey;
+        var handler = await CreateHandlerAsync(httpContext);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.Equal("jdoe", result.Principal!.FindFirst("username")?.Value);
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_ValidKey_UpdatesLastUsedAt()
+    {
+        var (user, rawKey) = await SeedUserWithApiKey();
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = rawKey;
+        var handler = await CreateHandlerAsync(httpContext);
+
+        await handler.AuthenticateAsync();
+
+        _context.ChangeTracker.Clear();
+        var key = await _context.ApiKeys.FirstAsync(k => k.UserId == user.Id);
+        Assert.NotNull(key.LastUsedAt);
+        Assert.True(key.LastUsedAt > DateTime.UtcNow.AddSeconds(-5));
+    }
+
+    [Fact]
+    public async Task HandleAuthenticate_WrongKey_DoesNotAuthenticate()
+    {
+        await SeedUserWithApiKey(rawKey: "dk_correctkey");
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Headers["X-API-Key"] = "dk_wrongkey";
+        var handler = await CreateHandlerAsync(httpContext);
+
+        var result = await handler.AuthenticateAsync();
+
+        Assert.False(result.Succeeded);
+    }
+
+    #endregion
+}

--- a/src/Deckle.MCP.Tests/Deckle.MCP.Tests.csproj
+++ b/src/Deckle.MCP.Tests/Deckle.MCP.Tests.csproj
@@ -1,0 +1,34 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="coverlet.collector" Version="8.0.0">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.0.1" />
+    <PackageReference Include="Moq" Version="4.20.72" />
+    <PackageReference Include="xunit" Version="2.9.3" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
+      <PrivateAssets>all</PrivateAssets>
+      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
+    </PackageReference>
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Deckle.MCP\Deckle.MCP.csproj" />
+    <ProjectReference Include="..\Deckle.Domain\Deckle.Domain.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Deckle.MCP.Tests/Tools/ComponentToolsTests.cs
+++ b/src/Deckle.MCP.Tests/Tools/ComponentToolsTests.cs
@@ -1,0 +1,482 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Deckle.MCP.Tools;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Deckle.MCP.Tests.Tools;
+
+public class ComponentToolsTests : IDisposable
+{
+    private bool _disposed;
+    private readonly AppDbContext _context;
+
+    public ComponentToolsTests()
+    {
+        _context = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+                _context.Dispose();
+            _disposed = true;
+        }
+    }
+
+    private ComponentTools CreateTools(Guid userId) => new(_context, CreateAccessor(userId));
+
+    private static IHttpContextAccessor CreateAccessor(Guid userId)
+    {
+        var claims = new ClaimsPrincipal(new ClaimsIdentity([new Claim("user_id", userId.ToString())]));
+        var ctx = new DefaultHttpContext { User = claims };
+        var mock = new Mock<IHttpContextAccessor>();
+        mock.Setup(a => a.HttpContext).Returns(ctx);
+        return mock.Object;
+    }
+
+    private async Task<(Guid userId, Guid projectId)> SeedOwnerWithProject()
+    {
+        var userId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        _context.Users.Add(new User { Id = userId, Email = $"{userId}@test.com", GoogleId = Guid.NewGuid().ToString(), CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _context.Projects.Add(new Project { Id = projectId, Name = "Test", Code = "t", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _context.UserProjects.Add(new UserProject { UserId = userId, ProjectId = projectId, Role = ProjectRole.Owner, JoinedAt = DateTime.UtcNow });
+        await _context.SaveChangesAsync();
+        return (userId, projectId);
+    }
+
+    private async Task<Card> SeedCard(Guid? projectId, string name = "Test Card")
+    {
+        var card = new Card { Id = Guid.NewGuid(), ProjectId = projectId, Name = name, Size = CardSize.StandardPoker, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        _context.Cards.Add(card);
+        await _context.SaveChangesAsync();
+        return card;
+    }
+
+    private async Task<Dice> SeedDice(Guid? projectId, string name = "Test Dice")
+    {
+        var dice = new Dice { Id = Guid.NewGuid(), ProjectId = projectId, Name = name, Type = DiceType.D6, Style = DiceStyle.Numbered, BaseColor = DiceColor.StarWhite, Number = 1, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow };
+        _context.Dices.Add(dice);
+        await _context.SaveChangesAsync();
+        return dice;
+    }
+
+    private async Task<GoogleSheetsDataSource> SeedDataSource(Guid projectId)
+    {
+        var ds = new GoogleSheetsDataSource
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            Name = "Sheet",
+            Type = DataSourceType.GoogleSheets,
+            GoogleSheetsId = "sheet123",
+            GoogleSheetsUrl = new Uri("https://docs.google.com/spreadsheets/d/sheet123/edit"),
+            SheetGid = 0,
+            CsvExportUrl = new Uri("https://docs.google.com/spreadsheets/d/sheet123/export?format=csv&gid=0"),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        _context.GoogleSheetsDataSources.Add(ds);
+        await _context.SaveChangesAsync();
+        return ds;
+    }
+
+    #region ListComponents
+
+    [Fact]
+    public async Task ListComponents_ProjectWithComponents_ReturnsAll()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedCard(projectId, "Card A");
+        await SeedDice(projectId, "Dice B");
+
+        var result = await CreateTools(userId).ListComponents(projectId);
+
+        var list = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Equal(2, list.Length);
+    }
+
+    [Fact]
+    public async Task ListComponents_NoAccess_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).ListComponents(projectId);
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    [Fact]
+    public async Task ListComponents_EmptyProject_ReturnsEmptyArray()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).ListComponents(projectId);
+
+        Assert.Empty(JsonSerializer.Deserialize<JsonElement[]>(result)!);
+    }
+
+    #endregion
+
+    #region GetComponent
+
+    [Fact]
+    public async Task GetComponent_Card_ReturnsCardTypeJson()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var card = await SeedCard(projectId);
+
+        var result = await CreateTools(userId).GetComponent(card.Id);
+
+        var obj = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("Card", obj.GetProperty("Type").GetString());
+        Assert.Equal("StandardPoker", obj.GetProperty("Size").GetString());
+    }
+
+    [Fact]
+    public async Task GetComponent_Dice_ReturnsDiceTypeJson()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var dice = await SeedDice(projectId);
+
+        var result = await CreateTools(userId).GetComponent(dice.Id);
+
+        var obj = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("Dice", obj.GetProperty("Type").GetString());
+        Assert.Equal("D6", obj.GetProperty("DiceType").GetString());
+    }
+
+    [Fact]
+    public async Task GetComponent_NotFound_ReturnsError()
+    {
+        var (userId, _) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).GetComponent(Guid.NewGuid());
+
+        Assert.Equal(McpErrors.ComponentNotFound, result);
+    }
+
+    [Fact]
+    public async Task GetComponent_SampleComponent_ReturnsNotFound()
+    {
+        var (userId, _) = await SeedOwnerWithProject();
+        var sample = await SeedCard(null);
+
+        var result = await CreateTools(userId).GetComponent(sample.Id);
+
+        Assert.Equal(McpErrors.ComponentNotFound, result);
+    }
+
+    [Fact]
+    public async Task GetComponent_OtherUsersComponent_ReturnsAccessDenied()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+        var card = await SeedCard(projectId);
+
+        var result = await CreateTools(Guid.NewGuid()).GetComponent(card.Id);
+
+        Assert.Equal(McpErrors.AccessDenied, result);
+    }
+
+    #endregion
+
+    #region CreateCard
+
+    [Fact]
+    public async Task CreateCard_ValidSize_PersistsCard()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateCard(projectId, "My Card", "Bridge");
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("Card", json.GetProperty("Type").GetString());
+        Assert.Equal("Bridge", json.GetProperty("Size").GetString());
+        _context.ChangeTracker.Clear();
+        Assert.NotNull(await _context.Cards.FirstOrDefaultAsync(c => c.Name == "My Card"));
+    }
+
+    [Fact]
+    public async Task CreateCard_DefaultsToStandardPokerPortrait()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateCard(projectId, "Default Card");
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("StandardPoker", json.GetProperty("Size").GetString());
+        Assert.False(json.GetProperty("Horizontal").GetBoolean());
+    }
+
+    [Fact]
+    public async Task CreateCard_InvalidSize_ReturnsErrorWithValidValues()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateCard(projectId, "Bad Card", "GiantCard");
+
+        Assert.Contains("error", result);
+        Assert.Contains("GiantCard", result);
+    }
+
+    [Fact]
+    public async Task CreateCard_NoAccess_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).CreateCard(projectId, "Card");
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    #endregion
+
+    #region CreateDice
+
+    [Fact]
+    public async Task CreateDice_ValidInput_PersistsDice()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateDice(projectId, "My D20", "D20", "Numbered", "StarWhite", 2);
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("Dice", json.GetProperty("Type").GetString());
+        Assert.Equal("D20", json.GetProperty("DiceType").GetString());
+        Assert.Equal(2, json.GetProperty("Number").GetInt32());
+    }
+
+    [Fact]
+    public async Task CreateDice_InvalidDiceType_ReturnsError()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateDice(projectId, "Die", "D100");
+
+        Assert.Contains("error", result);
+        Assert.Contains("D100", result);
+    }
+
+    [Fact]
+    public async Task CreateDice_InvalidStyle_ReturnsError()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateDice(projectId, "Die", "D6", "Fantasy");
+
+        Assert.Contains("error", result);
+        Assert.Contains("Fantasy", result);
+    }
+
+    [Fact]
+    public async Task CreateDice_InvalidColor_ReturnsError()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateDice(projectId, "Die", "D6", "Numbered", "Rainbow");
+
+        Assert.Contains("error", result);
+        Assert.Contains("Rainbow", result);
+    }
+
+    #endregion
+
+    #region CreateGameBoard
+
+    [Fact]
+    public async Task CreateGameBoard_PresetSize_PersistsBoard()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateGameBoard(projectId, "My Board", "MediumBifoldSquare");
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("GameBoard", json.GetProperty("Type").GetString());
+        Assert.Equal("MediumBifoldSquare", json.GetProperty("PresetSize").GetString());
+    }
+
+    [Fact]
+    public async Task CreateGameBoard_CustomDimensions_PresetSizeIsNull()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateGameBoard(projectId, "Custom Board", null, true, 300m, 400m);
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal(JsonValueKind.Null, json.GetProperty("PresetSize").ValueKind);
+    }
+
+    [Fact]
+    public async Task CreateGameBoard_InvalidPresetSize_ReturnsError()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateGameBoard(projectId, "Board", "MassiveBoard");
+
+        Assert.Contains("error", result);
+        Assert.Contains("MassiveBoard", result);
+    }
+
+    #endregion
+
+    #region CreatePlayerMat
+
+    [Fact]
+    public async Task CreatePlayerMat_PresetSize_PersistsMat()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreatePlayerMat(projectId, "My Mat", "A4");
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("PlayerMat", json.GetProperty("Type").GetString());
+        Assert.Equal("A4", json.GetProperty("PresetSize").GetString());
+    }
+
+    [Fact]
+    public async Task CreatePlayerMat_InvalidPresetSize_ReturnsError()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreatePlayerMat(projectId, "Mat", "A10");
+
+        Assert.Contains("error", result);
+    }
+
+    #endregion
+
+    #region DeleteComponent
+
+    [Fact]
+    public async Task DeleteComponent_ValidComponent_DeletesAndReturnsDeleted()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var card = await SeedCard(projectId);
+
+        var result = await CreateTools(userId).DeleteComponent(card.Id);
+
+        Assert.Equal(McpErrors.Deleted, result);
+        _context.ChangeTracker.Clear();
+        Assert.Null(await _context.Cards.FindAsync(card.Id));
+    }
+
+    [Fact]
+    public async Task DeleteComponent_NotFound_ReturnsError()
+    {
+        var (userId, _) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).DeleteComponent(Guid.NewGuid());
+
+        Assert.Equal(McpErrors.ComponentNotFound, result);
+    }
+
+    [Fact]
+    public async Task DeleteComponent_SampleComponent_ReturnsNotFound()
+    {
+        var (userId, _) = await SeedOwnerWithProject();
+        var sample = await SeedCard(null);
+
+        var result = await CreateTools(userId).DeleteComponent(sample.Id);
+
+        Assert.Equal(McpErrors.ComponentNotFound, result);
+    }
+
+    [Fact]
+    public async Task DeleteComponent_OtherUsersComponent_ReturnsAccessDenied()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+        var card = await SeedCard(projectId);
+
+        var result = await CreateTools(Guid.NewGuid()).DeleteComponent(card.Id);
+
+        Assert.Equal(McpErrors.AccessDenied, result);
+    }
+
+    #endregion
+
+    #region LinkDataSource
+
+    [Fact]
+    public async Task LinkDataSource_ValidLink_SetsDataSource()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var card = await SeedCard(projectId);
+        var ds = await SeedDataSource(projectId);
+
+        var result = await CreateTools(userId).LinkDataSource(card.Id, ds.Id);
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("updated", json.GetProperty("Status").GetString());
+        _context.ChangeTracker.Clear();
+        var updated = await _context.Cards.Include(c => c.DataSource).FirstAsync(c => c.Id == card.Id);
+        Assert.Equal(ds.Id, updated.DataSource!.Id);
+    }
+
+    [Fact]
+    public async Task LinkDataSource_NullDataSourceId_UnlinksDataSource()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var card = await SeedCard(projectId);
+        var ds = await SeedDataSource(projectId);
+        card.DataSource = ds;
+        await _context.SaveChangesAsync();
+
+        await CreateTools(userId).LinkDataSource(card.Id, null);
+
+        _context.ChangeTracker.Clear();
+        var updated = await _context.Cards.Include(c => c.DataSource).FirstAsync(c => c.Id == card.Id);
+        Assert.Null(updated.DataSource);
+    }
+
+    [Fact]
+    public async Task LinkDataSource_ComponentNotFound_ReturnsError()
+    {
+        var (userId, _) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).LinkDataSource(Guid.NewGuid(), null);
+
+        Assert.Equal(McpErrors.ComponentNotFound, result);
+    }
+
+    [Fact]
+    public async Task LinkDataSource_DiceDoesNotSupportDataSource_ReturnsError()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var dice = await SeedDice(projectId);
+
+        var result = await CreateTools(userId).LinkDataSource(dice.Id, null);
+
+        Assert.Contains("error", result);
+        Assert.Contains("not support data sources", result);
+    }
+
+    [Fact]
+    public async Task LinkDataSource_DataSourceFromDifferentProject_ReturnsError()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var card = await SeedCard(projectId);
+        var (_, otherProjectId) = await SeedOwnerWithProject();
+        var otherDs = await SeedDataSource(otherProjectId);
+
+        var result = await CreateTools(userId).LinkDataSource(card.Id, otherDs.Id);
+
+        Assert.Contains("error", result);
+        Assert.Contains("not found", result);
+    }
+
+    #endregion
+}

--- a/src/Deckle.MCP.Tests/Tools/DataSourceToolsTests.cs
+++ b/src/Deckle.MCP.Tests/Tools/DataSourceToolsTests.cs
@@ -1,0 +1,340 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Deckle.MCP.Tools;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Deckle.MCP.Tests.Tools;
+
+public class DataSourceToolsTests : IDisposable
+{
+    private bool _disposed;
+    private readonly AppDbContext _context;
+
+    public DataSourceToolsTests()
+    {
+        _context = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+                _context.Dispose();
+            _disposed = true;
+        }
+    }
+
+    private DataSourceTools CreateTools(Guid userId) => new(_context, CreateAccessor(userId));
+
+    private static IHttpContextAccessor CreateAccessor(Guid userId)
+    {
+        var claims = new ClaimsPrincipal(new ClaimsIdentity([new Claim("user_id", userId.ToString())]));
+        var ctx = new DefaultHttpContext { User = claims };
+        var mock = new Mock<IHttpContextAccessor>();
+        mock.Setup(a => a.HttpContext).Returns(ctx);
+        return mock.Object;
+    }
+
+    private async Task<(Guid userId, Guid projectId)> SeedOwnerWithProject()
+    {
+        var userId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        _context.Users.Add(new User { Id = userId, Email = $"{userId}@test.com", GoogleId = Guid.NewGuid().ToString(), CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _context.Projects.Add(new Project { Id = projectId, Name = "Test", Code = "t", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _context.UserProjects.Add(new UserProject { UserId = userId, ProjectId = projectId, Role = ProjectRole.Owner, JoinedAt = DateTime.UtcNow });
+        await _context.SaveChangesAsync();
+        return (userId, projectId);
+    }
+
+    private async Task<GoogleSheetsDataSource> SeedGoogleSheetsSource(
+        Guid projectId,
+        string name = "Test Sheet",
+        string sheetId = "abc123",
+        int gid = 0,
+        List<string>? headers = null)
+    {
+        var ds = new GoogleSheetsDataSource
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            Name = name,
+            Type = DataSourceType.GoogleSheets,
+            GoogleSheetsId = sheetId,
+            GoogleSheetsUrl = new Uri($"https://docs.google.com/spreadsheets/d/{sheetId}/edit"),
+            SheetGid = gid,
+            CsvExportUrl = new Uri($"https://docs.google.com/spreadsheets/d/{sheetId}/export?format=csv&gid={gid}"),
+            Headers = headers ?? ["Name", "Value"],
+            RowCount = 10,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        _context.GoogleSheetsDataSources.Add(ds);
+        await _context.SaveChangesAsync();
+        return ds;
+    }
+
+    #region ListDataSources
+
+    [Fact]
+    public async Task ListDataSources_ProjectWithSources_ReturnsAll()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedGoogleSheetsSource(projectId, "Sheet 1");
+        await SeedGoogleSheetsSource(projectId, "Sheet 2", "xyz789");
+
+        var result = await CreateTools(userId).ListDataSources(projectId);
+
+        Assert.Equal(2, JsonSerializer.Deserialize<JsonElement[]>(result)!.Length);
+    }
+
+    [Fact]
+    public async Task ListDataSources_NoAccess_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).ListDataSources(projectId);
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    [Fact]
+    public async Task ListDataSources_IncludesHeadersAndRowCount()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedGoogleSheetsSource(projectId, headers: ["Col1", "Col2"]);
+
+        var result = await CreateTools(userId).ListDataSources(projectId);
+
+        var item = JsonSerializer.Deserialize<JsonElement[]>(result)![0];
+        Assert.Equal(2, item.GetProperty("Headers").GetArrayLength());
+    }
+
+    #endregion
+
+    #region GetDataSource
+
+    [Fact]
+    public async Task GetDataSource_GoogleSheets_ReturnsUrlFields()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var ds = await SeedGoogleSheetsSource(projectId, sheetId: "mySheetId");
+
+        var result = await CreateTools(userId).GetDataSource(ds.Id);
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("GoogleSheets", json.GetProperty("Type").GetString());
+        Assert.Equal("mySheetId", json.GetProperty("GoogleSheetsId").GetString());
+        Assert.NotNull(json.GetProperty("CsvExportUrl").GetString());
+    }
+
+    [Fact]
+    public async Task GetDataSource_NotFound_ReturnsError()
+    {
+        var (userId, _) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).GetDataSource(Guid.NewGuid());
+
+        Assert.Equal(McpErrors.DataSourceNotFound, result);
+    }
+
+    [Fact]
+    public async Task GetDataSource_OtherUsersProject_ReturnsAccessDenied()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+        var ds = await SeedGoogleSheetsSource(projectId);
+
+        var result = await CreateTools(Guid.NewGuid()).GetDataSource(ds.Id);
+
+        Assert.Equal(McpErrors.AccessDenied, result);
+    }
+
+    #endregion
+
+    #region CreateGoogleSheetsDataSource
+
+    [Fact]
+    public async Task CreateGoogleSheetsDataSource_StandardUrl_ExtractsSpreadsheetId()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        const string url = "https://docs.google.com/spreadsheets/d/1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms/edit#gid=0";
+
+        var result = await CreateTools(userId).CreateGoogleSheetsDataSource(projectId, "My Sheet", url);
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("1BxiMVs0XRA5nFMdKvBdBZjgmUUqptlbs74OgVE2upms", json.GetProperty("GoogleSheetsId").GetString());
+    }
+
+    [Fact]
+    public async Task CreateGoogleSheetsDataSource_UrlWithGid_ExtractsSheetGid()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        const string url = "https://docs.google.com/spreadsheets/d/abc123/edit?gid=99";
+
+        var result = await CreateTools(userId).CreateGoogleSheetsDataSource(projectId, "Sheet", url);
+
+        var json = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal(99, json.GetProperty("SheetGid").GetInt32());
+    }
+
+    [Fact]
+    public async Task CreateGoogleSheetsDataSource_UrlWithoutGid_DefaultsGidToZero()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        const string url = "https://docs.google.com/spreadsheets/d/abc123/edit";
+
+        var result = await CreateTools(userId).CreateGoogleSheetsDataSource(projectId, "Sheet", url);
+
+        Assert.Equal(0, JsonSerializer.Deserialize<JsonElement>(result).GetProperty("SheetGid").GetInt32());
+    }
+
+    [Fact]
+    public async Task CreateGoogleSheetsDataSource_BuildsCsvExportUrl()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        const string url = "https://docs.google.com/spreadsheets/d/myid/edit#gid=5";
+
+        var result = await CreateTools(userId).CreateGoogleSheetsDataSource(projectId, "Sheet", url);
+
+        var csvUrl = JsonSerializer.Deserialize<JsonElement>(result).GetProperty("CsvExportUrl").GetString()!;
+        Assert.Contains("myid", csvUrl);
+        Assert.Contains("format=csv", csvUrl);
+        Assert.Contains("gid=5", csvUrl);
+    }
+
+    [Fact]
+    public async Task CreateGoogleSheetsDataSource_InvalidUrl_ReturnsError()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateGoogleSheetsDataSource(projectId, "Sheet", "not-a-url");
+
+        Assert.Contains("error", result);
+        Assert.Contains("Invalid", result);
+    }
+
+    [Fact]
+    public async Task CreateGoogleSheetsDataSource_UrlWithNoSpreadsheetId_ReturnsError()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).CreateGoogleSheetsDataSource(projectId, "Sheet", "https://example.com/notsheets");
+
+        Assert.Contains("error", result);
+    }
+
+    [Fact]
+    public async Task CreateGoogleSheetsDataSource_NoAccess_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).CreateGoogleSheetsDataSource(projectId, "Sheet",
+            "https://docs.google.com/spreadsheets/d/abc123/edit");
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    [Fact]
+    public async Task CreateGoogleSheetsDataSource_PersistsToDatabase()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        const string url = "https://docs.google.com/spreadsheets/d/persistedId/edit";
+
+        await CreateTools(userId).CreateGoogleSheetsDataSource(projectId, "Saved Sheet", url);
+
+        _context.ChangeTracker.Clear();
+        Assert.NotNull(await _context.GoogleSheetsDataSources.FirstOrDefaultAsync(d => d.Name == "Saved Sheet"));
+    }
+
+    #endregion
+
+    #region SyncDataSourceMetadata
+
+    [Fact]
+    public async Task SyncDataSourceMetadata_UpdatesHeadersAndRowCount()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var ds = await SeedGoogleSheetsSource(projectId);
+
+        var result = await CreateTools(userId).SyncDataSourceMetadata(ds.Id, ["A", "B", "C"], 42);
+
+        Assert.Contains("synced", result);
+        _context.ChangeTracker.Clear();
+        var updated = await _context.DataSources.FindAsync(ds.Id);
+        Assert.Equal(42, updated!.RowCount);
+        Assert.Equal(3, updated!.Headers.Count);
+    }
+
+    [Fact]
+    public async Task SyncDataSourceMetadata_NotFound_ReturnsError()
+    {
+        var (userId, _) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).SyncDataSourceMetadata(Guid.NewGuid(), ["A"], 1);
+
+        Assert.Equal(McpErrors.DataSourceNotFound, result);
+    }
+
+    [Fact]
+    public async Task SyncDataSourceMetadata_OtherUsersSource_ReturnsAccessDenied()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+        var ds = await SeedGoogleSheetsSource(projectId);
+
+        var result = await CreateTools(Guid.NewGuid()).SyncDataSourceMetadata(ds.Id, ["A"], 1);
+
+        Assert.Equal(McpErrors.AccessDenied, result);
+    }
+
+    #endregion
+
+    #region DeleteDataSource
+
+    [Fact]
+    public async Task DeleteDataSource_Owner_DeletesAndReturnsDeleted()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        var ds = await SeedGoogleSheetsSource(projectId);
+
+        var result = await CreateTools(userId).DeleteDataSource(ds.Id);
+
+        Assert.Equal(McpErrors.Deleted, result);
+        _context.ChangeTracker.Clear();
+        Assert.Null(await _context.DataSources.FindAsync(ds.Id));
+    }
+
+    [Fact]
+    public async Task DeleteDataSource_NotFound_ReturnsError()
+    {
+        var (userId, _) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).DeleteDataSource(Guid.NewGuid());
+
+        Assert.Equal(McpErrors.DataSourceNotFound, result);
+    }
+
+    [Fact]
+    public async Task DeleteDataSource_OtherUsersProject_ReturnsAccessDenied()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+        var ds = await SeedGoogleSheetsSource(projectId);
+
+        var result = await CreateTools(Guid.NewGuid()).DeleteDataSource(ds.Id);
+
+        Assert.Equal(McpErrors.AccessDenied, result);
+    }
+
+    #endregion
+}

--- a/src/Deckle.MCP.Tests/Tools/FileToolsTests.cs
+++ b/src/Deckle.MCP.Tests/Tools/FileToolsTests.cs
@@ -1,0 +1,282 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Deckle.MCP.Tools;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+using File = Deckle.Domain.Entities.File;
+
+namespace Deckle.MCP.Tests.Tools;
+
+public class FileToolsTests : IDisposable
+{
+    private bool _disposed;
+    private readonly AppDbContext _context;
+
+    public FileToolsTests()
+    {
+        _context = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+                _context.Dispose();
+            _disposed = true;
+        }
+    }
+
+    private FileTools CreateTools(Guid userId) => new(_context, CreateAccessor(userId));
+
+    private static IHttpContextAccessor CreateAccessor(Guid userId)
+    {
+        var claims = new ClaimsPrincipal(new ClaimsIdentity([new Claim("user_id", userId.ToString())]));
+        var ctx = new DefaultHttpContext { User = claims };
+        var mock = new Mock<IHttpContextAccessor>();
+        mock.Setup(a => a.HttpContext).Returns(ctx);
+        return mock.Object;
+    }
+
+    private async Task<(Guid userId, Guid projectId)> SeedOwnerWithProject()
+    {
+        var userId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        _context.Users.Add(new User { Id = userId, Email = $"{userId}@test.com", GoogleId = Guid.NewGuid().ToString(), CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _context.Projects.Add(new Project { Id = projectId, Name = "Test", Code = "t", CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _context.UserProjects.Add(new UserProject { UserId = userId, ProjectId = projectId, Role = ProjectRole.Owner, JoinedAt = DateTime.UtcNow });
+        await _context.SaveChangesAsync();
+        return (userId, projectId);
+    }
+
+    private async Task<File> SeedFile(
+        Guid projectId,
+        Guid uploadedById,
+        string fileName = "test.png",
+        string path = "images/test.png",
+        FileStatus status = FileStatus.Confirmed,
+        List<string>? tags = null)
+    {
+        var file = new File
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            UploadedByUserId = uploadedById,
+            FileName = fileName,
+            Path = path,
+            ContentType = "image/png",
+            TotalByteSize = 1024,
+            StorageKey = path,
+            Status = status,
+            Tags = tags ?? [],
+            UploadedAt = DateTime.UtcNow
+        };
+        _context.Files.Add(file);
+        await _context.SaveChangesAsync();
+        return file;
+    }
+
+    private async Task<FileDirectory> SeedDirectory(Guid projectId, string name = "Images")
+    {
+        var dir = new FileDirectory
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            Name = name,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+        _context.FileDirectories.Add(dir);
+        await _context.SaveChangesAsync();
+        return dir;
+    }
+
+    #region ListFiles
+
+    [Fact]
+    public async Task ListFiles_ConfirmedFiles_ReturnsAll()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedFile(projectId, userId, "a.png", "a.png");
+        await SeedFile(projectId, userId, "b.png", "b.png");
+
+        var result = await CreateTools(userId).ListFiles(projectId);
+
+        Assert.Equal(2, JsonSerializer.Deserialize<JsonElement[]>(result)!.Length);
+    }
+
+    [Fact]
+    public async Task ListFiles_ExcludesPendingFiles()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedFile(projectId, userId, status: FileStatus.Confirmed);
+        await SeedFile(projectId, userId, "pending.png", "pending.png", FileStatus.Pending);
+
+        var result = await CreateTools(userId).ListFiles(projectId);
+
+        Assert.Single(JsonSerializer.Deserialize<JsonElement[]>(result)!);
+    }
+
+    [Fact]
+    public async Task ListFiles_TagFilter_ReturnsOnlyMatchingFiles()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedFile(projectId, userId, "card.png", "card.png", tags: ["card", "art"]);
+        await SeedFile(projectId, userId, "token.png", "token.png", tags: ["token"]);
+
+        var result = await CreateTools(userId).ListFiles(projectId, "card");
+
+        var files = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Single(files);
+        Assert.Equal("card.png", files[0].GetProperty("FileName").GetString());
+    }
+
+    [Fact]
+    public async Task ListFiles_NoMatchingTag_ReturnsEmpty()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedFile(projectId, userId, tags: ["art"]);
+
+        var result = await CreateTools(userId).ListFiles(projectId, "missing-tag");
+
+        Assert.Empty(JsonSerializer.Deserialize<JsonElement[]>(result)!);
+    }
+
+    [Fact]
+    public async Task ListFiles_NoAccess_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).ListFiles(projectId);
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    [Fact]
+    public async Task ListFiles_OrderedByPath()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedFile(projectId, userId, "z.png", "z/z.png");
+        await SeedFile(projectId, userId, "a.png", "a/a.png");
+
+        var result = await CreateTools(userId).ListFiles(projectId);
+
+        var files = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Equal("a/a.png", files[0].GetProperty("Path").GetString());
+        Assert.Equal("z/z.png", files[1].GetProperty("Path").GetString());
+    }
+
+    #endregion
+
+    #region ListDirectories
+
+    [Fact]
+    public async Task ListDirectories_ProjectWithDirs_ReturnsAll()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedDirectory(projectId, "Images");
+        await SeedDirectory(projectId, "Tokens");
+
+        var result = await CreateTools(userId).ListDirectories(projectId);
+
+        Assert.Equal(2, JsonSerializer.Deserialize<JsonElement[]>(result)!.Length);
+    }
+
+    [Fact]
+    public async Task ListDirectories_NoDirs_ReturnsEmpty()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).ListDirectories(projectId);
+
+        Assert.Empty(JsonSerializer.Deserialize<JsonElement[]>(result)!);
+    }
+
+    [Fact]
+    public async Task ListDirectories_NoAccess_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).ListDirectories(projectId);
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    [Fact]
+    public async Task ListDirectories_OrderedByName()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedDirectory(projectId, "Zebra");
+        await SeedDirectory(projectId, "Alpha");
+
+        var result = await CreateTools(userId).ListDirectories(projectId);
+
+        var dirs = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Equal("Alpha", dirs[0].GetProperty("Name").GetString());
+        Assert.Equal("Zebra", dirs[1].GetProperty("Name").GetString());
+    }
+
+    #endregion
+
+    #region ListFileTags
+
+    [Fact]
+    public async Task ListFileTags_ReturnsDistinctSortedTags()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedFile(projectId, userId, "a.png", "a.png", tags: ["zebra", "art"]);
+        await SeedFile(projectId, userId, "b.png", "b.png", tags: ["art", "card"]);
+
+        var result = await CreateTools(userId).ListFileTags(projectId);
+
+        var tags = JsonSerializer.Deserialize<string[]>(result)!;
+        Assert.Equal(["art", "card", "zebra"], tags);
+    }
+
+    [Fact]
+    public async Task ListFileTags_ExcludesPendingFileTags()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+        await SeedFile(projectId, userId, status: FileStatus.Confirmed, tags: ["confirmed-tag"]);
+        await SeedFile(projectId, userId, "p.png", "p.png", FileStatus.Pending, tags: ["pending-tag"]);
+
+        var result = await CreateTools(userId).ListFileTags(projectId);
+
+        var tags = JsonSerializer.Deserialize<string[]>(result)!;
+        Assert.Contains("confirmed-tag", tags);
+        Assert.DoesNotContain("pending-tag", tags);
+    }
+
+    [Fact]
+    public async Task ListFileTags_NoFiles_ReturnsEmpty()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).ListFileTags(projectId);
+
+        Assert.Empty(JsonSerializer.Deserialize<string[]>(result)!);
+    }
+
+    [Fact]
+    public async Task ListFileTags_NoAccess_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).ListFileTags(projectId);
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    #endregion
+}

--- a/src/Deckle.MCP.Tests/Tools/ProjectToolsTests.cs
+++ b/src/Deckle.MCP.Tests/Tools/ProjectToolsTests.cs
@@ -1,0 +1,353 @@
+using System.Security.Claims;
+using System.Text.Json;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Deckle.MCP.Tools;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using Moq;
+
+namespace Deckle.MCP.Tests.Tools;
+
+public class ProjectToolsTests : IDisposable
+{
+    private bool _disposed;
+    private readonly AppDbContext _context;
+
+    public ProjectToolsTests()
+    {
+        _context = new AppDbContext(new DbContextOptionsBuilder<AppDbContext>()
+            .UseInMemoryDatabase(Guid.NewGuid().ToString())
+            .Options);
+    }
+
+    public void Dispose()
+    {
+        Dispose(true);
+        GC.SuppressFinalize(this);
+    }
+
+    protected virtual void Dispose(bool disposing)
+    {
+        if (!_disposed)
+        {
+            if (disposing)
+                _context.Dispose();
+            _disposed = true;
+        }
+    }
+
+    private ProjectTools CreateTools(Guid userId) => new(_context, CreateAccessor(userId));
+
+    private static IHttpContextAccessor CreateAccessor(Guid userId)
+    {
+        var claims = new ClaimsPrincipal(new ClaimsIdentity([new Claim("user_id", userId.ToString())]));
+        var ctx = new DefaultHttpContext { User = claims };
+        var mock = new Mock<IHttpContextAccessor>();
+        mock.Setup(a => a.HttpContext).Returns(ctx);
+        return mock.Object;
+    }
+
+    private async Task<Guid> SeedUser(string username = "testuser")
+    {
+        var userId = Guid.NewGuid();
+        _context.Users.Add(new User
+        {
+            Id = userId,
+            Email = $"{userId}@test.com",
+            Username = username,
+            GoogleId = Guid.NewGuid().ToString(),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+        return userId;
+    }
+
+    private async Task<(Guid userId, Guid projectId)> SeedOwnerWithProject(
+        string projectName = "Test Project",
+        string code = "test-project",
+        string username = "testuser")
+    {
+        var userId = Guid.NewGuid();
+        var projectId = Guid.NewGuid();
+        _context.Users.Add(new User { Id = userId, Email = $"{userId}@test.com", Username = username, GoogleId = Guid.NewGuid().ToString(), CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _context.Projects.Add(new Project { Id = projectId, Name = projectName, Code = code, CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _context.UserProjects.Add(new UserProject { UserId = userId, ProjectId = projectId, Role = ProjectRole.Owner, JoinedAt = DateTime.UtcNow });
+        await _context.SaveChangesAsync();
+        return (userId, projectId);
+    }
+
+    #region ListProjects
+
+    [Fact]
+    public async Task ListProjects_UserWithProjects_ReturnsProjectList()
+    {
+        var (userId, _) = await SeedOwnerWithProject("My Game");
+
+        var result = await CreateTools(userId).ListProjects();
+
+        var list = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Single(list);
+        Assert.Equal("My Game", list[0].GetProperty("Name").GetString());
+    }
+
+    [Fact]
+    public async Task ListProjects_UserWithNoProjects_ReturnsEmptyArray()
+    {
+        var result = await CreateTools(Guid.NewGuid()).ListProjects();
+
+        var list = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Empty(list);
+    }
+
+    [Fact]
+    public async Task ListProjects_IncludesOwnerUsernameAndRole()
+    {
+        var (userId, _) = await SeedOwnerWithProject(username: "jsmith");
+
+        var result = await CreateTools(userId).ListProjects();
+
+        var list = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Equal("jsmith", list[0].GetProperty("OwnerUsername").GetString());
+        Assert.Equal("Owner", list[0].GetProperty("Role").GetString());
+    }
+
+    [Fact]
+    public async Task ListProjects_DoesNotReturnOtherUsersProjects()
+    {
+        await SeedOwnerWithProject("Other Game");
+        var myUserId = await SeedUser("me");
+
+        var result = await CreateTools(myUserId).ListProjects();
+
+        var list = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Empty(list);
+    }
+
+    #endregion
+
+    #region GetProject
+
+    [Fact]
+    public async Task GetProject_MemberProject_ReturnsProjectJson()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject("Board Game");
+
+        var result = await CreateTools(userId).GetProject(projectId);
+
+        var obj = JsonSerializer.Deserialize<JsonElement>(result);
+        Assert.Equal("Board Game", obj.GetProperty("Name").GetString());
+        Assert.Equal(projectId, obj.GetProperty("Id").GetGuid());
+    }
+
+    [Fact]
+    public async Task GetProject_NonMember_ReturnsNotFoundError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).GetProject(projectId);
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    [Fact]
+    public async Task GetProject_UnknownProjectId_ReturnsNotFoundError()
+    {
+        var userId = await SeedUser();
+
+        var result = await CreateTools(userId).GetProject(Guid.NewGuid());
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    #endregion
+
+    #region CreateProject
+
+    [Fact]
+    public async Task CreateProject_ValidInput_PersistsProject()
+    {
+        var userId = await SeedUser();
+
+        await CreateTools(userId).CreateProject("New Game", "new-game", "A description");
+
+        _context.ChangeTracker.Clear();
+        var project = await _context.Projects.FirstOrDefaultAsync(p => p.Name == "New Game");
+        Assert.NotNull(project);
+        Assert.Equal("new-game", project.Code);
+        Assert.Equal("A description", project.Description);
+    }
+
+    [Fact]
+    public async Task CreateProject_CreatesOwnerUserProject()
+    {
+        var userId = await SeedUser();
+
+        var result = await CreateTools(userId).CreateProject("Card Game", "card-game");
+
+        var projectId = JsonSerializer.Deserialize<JsonElement>(result).GetProperty("Id").GetGuid();
+        _context.ChangeTracker.Clear();
+        var up = await _context.UserProjects.FindAsync(userId, projectId);
+        Assert.NotNull(up);
+        Assert.Equal(ProjectRole.Owner, up.Role);
+    }
+
+    [Fact]
+    public async Task CreateProject_DefaultsToPrivateVisibility()
+    {
+        var userId = await SeedUser();
+
+        var result = await CreateTools(userId).CreateProject("Secret Game", "secret-game");
+
+        Assert.Equal("Private", JsonSerializer.Deserialize<JsonElement>(result).GetProperty("Visibility").GetString());
+    }
+
+    [Fact]
+    public async Task CreateProject_PublicVisibility_PersistedCorrectly()
+    {
+        var userId = await SeedUser();
+
+        var result = await CreateTools(userId).CreateProject("Open Game", "open-game", visibility: "Public");
+
+        Assert.Equal("Public", JsonSerializer.Deserialize<JsonElement>(result).GetProperty("Visibility").GetString());
+    }
+
+    [Fact]
+    public async Task CreateProject_InvalidVisibilityString_DefaultsToPrivate()
+    {
+        var userId = await SeedUser();
+
+        var result = await CreateTools(userId).CreateProject("Game", "game", visibility: "NotAVisibility");
+
+        Assert.Equal("Private", JsonSerializer.Deserialize<JsonElement>(result).GetProperty("Visibility").GetString());
+    }
+
+    #endregion
+
+    #region UpdateProject
+
+    [Fact]
+    public async Task UpdateProject_Owner_UpdatesNameAndReturnsStatus()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).UpdateProject(projectId, "Renamed Game");
+
+        Assert.Equal("updated", JsonSerializer.Deserialize<JsonElement>(result).GetProperty("Status").GetString());
+        _context.ChangeTracker.Clear();
+        var project = await _context.Projects.FindAsync(projectId);
+        Assert.Equal("Renamed Game", project!.Name);
+    }
+
+    [Fact]
+    public async Task UpdateProject_Owner_UpdatesDescription()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        await CreateTools(userId).UpdateProject(projectId, "Game", "New desc");
+
+        _context.ChangeTracker.Clear();
+        Assert.Equal("New desc", (await _context.Projects.FindAsync(projectId))!.Description);
+    }
+
+    [Fact]
+    public async Task UpdateProject_NonOwner_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+        var otherId = await SeedUser("other");
+
+        var result = await CreateTools(otherId).UpdateProject(projectId, "Hack");
+
+        Assert.Equal(McpErrors.ProjectNotFoundOrNotOwner, result);
+    }
+
+    [Fact]
+    public async Task UpdateProject_UnknownProject_ReturnsError()
+    {
+        var userId = await SeedUser();
+
+        var result = await CreateTools(userId).UpdateProject(Guid.NewGuid(), "Name");
+
+        Assert.Equal(McpErrors.ProjectNotFoundOrNotOwner, result);
+    }
+
+    #endregion
+
+    #region DeleteProject
+
+    [Fact]
+    public async Task DeleteProject_Owner_DeletesAndReturnsDeleted()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).DeleteProject(projectId);
+
+        Assert.Equal(McpErrors.Deleted, result);
+        _context.ChangeTracker.Clear();
+        Assert.Null(await _context.Projects.FindAsync(projectId));
+    }
+
+    [Fact]
+    public async Task DeleteProject_NonOwner_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).DeleteProject(projectId);
+
+        Assert.Equal(McpErrors.ProjectNotFoundOrNotOwner, result);
+    }
+
+    [Fact]
+    public async Task DeleteProject_UnknownProject_ReturnsError()
+    {
+        var userId = await SeedUser();
+
+        var result = await CreateTools(userId).DeleteProject(Guid.NewGuid());
+
+        Assert.Equal(McpErrors.ProjectNotFoundOrNotOwner, result);
+    }
+
+    #endregion
+
+    #region ListProjectMembers
+
+    [Fact]
+    public async Task ListProjectMembers_Member_ReturnsMemberList()
+    {
+        var (userId, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(userId).ListProjectMembers(projectId);
+
+        var members = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Single(members);
+        Assert.Equal("Owner", members[0].GetProperty("Role").GetString());
+    }
+
+    [Fact]
+    public async Task ListProjectMembers_NonMember_ReturnsError()
+    {
+        var (_, projectId) = await SeedOwnerWithProject();
+
+        var result = await CreateTools(Guid.NewGuid()).ListProjectMembers(projectId);
+
+        Assert.Equal(McpErrors.ProjectNotFound, result);
+    }
+
+    [Fact]
+    public async Task ListProjectMembers_MultipleMembers_ReturnsAll()
+    {
+        var (ownerId, projectId) = await SeedOwnerWithProject();
+        var collabId = Guid.NewGuid();
+        _context.Users.Add(new User { Id = collabId, Email = "collab@test.com", GoogleId = Guid.NewGuid().ToString(), CreatedAt = DateTime.UtcNow, UpdatedAt = DateTime.UtcNow });
+        _context.UserProjects.Add(new UserProject { UserId = collabId, ProjectId = projectId, Role = ProjectRole.Collaborator, JoinedAt = DateTime.UtcNow });
+        await _context.SaveChangesAsync();
+
+        var result = await CreateTools(ownerId).ListProjectMembers(projectId);
+
+        var members = JsonSerializer.Deserialize<JsonElement[]>(result)!;
+        Assert.Equal(2, members.Length);
+    }
+
+    #endregion
+}

--- a/src/Deckle.MCP/Auth/ApiKeyAuthenticationHandler.cs
+++ b/src/Deckle.MCP/Auth/ApiKeyAuthenticationHandler.cs
@@ -1,0 +1,55 @@
+using System.Security.Claims;
+using System.Security.Cryptography;
+using System.Text;
+using System.Text.Encodings.Web;
+using Deckle.Domain.Data;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
+
+namespace Deckle.MCP.Auth;
+
+public class ApiKeyAuthenticationHandler(
+    IOptionsMonitor<AuthenticationSchemeOptions> options,
+    ILoggerFactory logger,
+    UrlEncoder encoder,
+    AppDbContext db)
+    : AuthenticationHandler<AuthenticationSchemeOptions>(options, logger, encoder)
+{
+    public const string SchemeName = "ApiKey";
+
+    protected override async Task<AuthenticateResult> HandleAuthenticateAsync()
+    {
+        if (!Request.Headers.TryGetValue("X-API-Key", out var apiKeyValue))
+            return AuthenticateResult.Fail("Missing X-API-Key header");
+
+        var rawKey = apiKeyValue.ToString();
+        if (string.IsNullOrWhiteSpace(rawKey))
+            return AuthenticateResult.Fail("Empty X-API-Key header");
+
+        var keyHash = Convert.ToHexString(SHA256.HashData(Encoding.UTF8.GetBytes(rawKey)));
+
+        var apiKey = await db.ApiKeys
+            .Include(k => k.User)
+            .FirstOrDefaultAsync(k => k.KeyHash == keyHash);
+
+        if (apiKey == null)
+            return AuthenticateResult.Fail("Invalid API key");
+
+        apiKey.LastUsedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+
+        var claims = new[]
+        {
+            new Claim(ClaimTypes.NameIdentifier, apiKey.UserId.ToString()),
+            new Claim("user_id", apiKey.UserId.ToString()),
+            new Claim(ClaimTypes.Email, apiKey.User.Email),
+            new Claim("username", apiKey.User.Username ?? string.Empty),
+            new Claim("Role", apiKey.User.Role.ToString()),
+        };
+
+        var identity = new ClaimsIdentity(claims, Scheme.Name);
+        var principal = new ClaimsPrincipal(identity);
+        return AuthenticateResult.Success(new AuthenticationTicket(principal, Scheme.Name));
+    }
+}

--- a/src/Deckle.MCP/Deckle.MCP.csproj
+++ b/src/Deckle.MCP/Deckle.MCP.csproj
@@ -1,0 +1,20 @@
+<Project Sdk="Microsoft.NET.Sdk.Web">
+
+  <PropertyGroup>
+    <TargetFramework>net10.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UserSecretsId>b2f3c1d4-e5a6-47b8-9c0d-1e2f3a4b5c6d</UserSecretsId>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Aspire.Npgsql.EntityFrameworkCore.PostgreSQL" Version="13.1.1" />
+    <PackageReference Include="ModelContextProtocol.AspNetCore" Version="1.3.0" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\Deckle.Domain\Deckle.Domain.csproj" />
+    <ProjectReference Include="..\Deckle.ServiceDefaults\Deckle.ServiceDefaults.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/src/Deckle.MCP/Deckle.MCP.csproj
+++ b/src/Deckle.MCP/Deckle.MCP.csproj
@@ -17,4 +17,10 @@
     <ProjectReference Include="..\Deckle.ServiceDefaults\Deckle.ServiceDefaults.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <AssemblyAttribute Include="System.Runtime.CompilerServices.InternalsVisibleToAttribute">
+      <_Parameter1>Deckle.MCP.Tests</_Parameter1>
+    </AssemblyAttribute>
+  </ItemGroup>
+
 </Project>

--- a/src/Deckle.MCP/Dockerfile
+++ b/src/Deckle.MCP/Dockerfile
@@ -1,0 +1,31 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:10.0 AS build
+
+WORKDIR /src
+
+COPY ["Deckle.MCP/Deckle.MCP.csproj", "Deckle.MCP/"]
+COPY ["Deckle.Domain/Deckle.Domain.csproj", "Deckle.Domain/"]
+COPY ["Deckle.ServiceDefaults/Deckle.ServiceDefaults.csproj", "Deckle.ServiceDefaults/"]
+COPY ["Deckle.Utils/Deckle.Utils.csproj", "Deckle.Utils/"]
+
+RUN dotnet restore "Deckle.MCP/Deckle.MCP.csproj"
+
+COPY . .
+
+WORKDIR "/src/Deckle.MCP"
+RUN dotnet build "Deckle.MCP.csproj" -c Release -o /app/build
+
+# Publish stage
+FROM build AS publish
+RUN dotnet publish "Deckle.MCP.csproj" -c Release -o /app/publish
+
+# Runtime stage
+FROM mcr.microsoft.com/dotnet/aspnet:10.0 AS runtime
+
+WORKDIR /app
+COPY --from=publish /app/publish .
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+
+ENTRYPOINT ["dotnet", "Deckle.MCP.dll"]

--- a/src/Deckle.MCP/Program.cs
+++ b/src/Deckle.MCP/Program.cs
@@ -1,0 +1,36 @@
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Deckle.MCP.Auth;
+using Deckle.MCP.Tools;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.EntityFrameworkCore;
+
+var builder = WebApplication.CreateBuilder(args);
+
+builder.AddServiceDefaults();
+builder.AddNpgsqlDbContext<AppDbContext>("deckledb", configureDbContextOptions: options =>
+    options.AddInterceptors(new ByteSizeInterceptor(), new StorageQuotaInterceptor()));
+
+builder.Services.AddAuthentication(ApiKeyAuthenticationHandler.SchemeName)
+    .AddScheme<AuthenticationSchemeOptions, ApiKeyAuthenticationHandler>(
+        ApiKeyAuthenticationHandler.SchemeName, null);
+
+builder.Services.AddAuthorization();
+builder.Services.AddHttpContextAccessor();
+
+builder.Services
+    .AddMcpServer()
+    .WithHttpTransport()
+    .WithTools<ProjectTools>()
+    .WithTools<ComponentTools>()
+    .WithTools<DataSourceTools>()
+    .WithTools<FileTools>();
+
+var app = builder.Build();
+
+app.UseAuthentication();
+app.UseAuthorization();
+
+app.MapMcp("/mcp").RequireAuthorization();
+
+await app.RunAsync();

--- a/src/Deckle.MCP/Tools/BaseMcpTool.cs
+++ b/src/Deckle.MCP/Tools/BaseMcpTool.cs
@@ -1,0 +1,20 @@
+using Deckle.Domain.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+
+namespace Deckle.MCP.Tools;
+
+public abstract class BaseMcpTool(AppDbContext db, IHttpContextAccessor httpContextAccessor)
+{
+    protected AppDbContext Db { get; } = db;
+    protected Guid UserId => GetUserId();
+
+    private Guid GetUserId()
+    {
+        var claim = httpContextAccessor.HttpContext?.User?.FindFirst("user_id")?.Value;
+        return Guid.TryParse(claim, out var id) ? id : throw new UnauthorizedAccessException("Not authenticated");
+    }
+
+    protected async Task<bool> HasProjectAccessAsync(Guid projectId) =>
+        await Db.UserProjects.AnyAsync(up => up.UserId == UserId && up.ProjectId == projectId);
+}

--- a/src/Deckle.MCP/Tools/ComponentTools.cs
+++ b/src/Deckle.MCP/Tools/ComponentTools.cs
@@ -174,10 +174,12 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             return McpErrors.ProjectNotFound;
 
         GameBoardSize? gbSize = null;
-        if (presetSize != null && !Enum.TryParse<GameBoardSize>(presetSize, out var parsedSize))
-            return $"{{\"error\":\"Invalid GameBoardSize '{presetSize}'\"}}";
-        else if (presetSize != null)
-            gbSize = Enum.Parse<GameBoardSize>(presetSize);
+        if (presetSize != null)
+        {
+            if (!Enum.TryParse<GameBoardSize>(presetSize, out var gbSizeParsed))
+                return $"{{\"error\":\"Invalid GameBoardSize '{presetSize}'\"}}";
+            gbSize = gbSizeParsed;
+        }
 
         var board = new GameBoard
         {
@@ -217,10 +219,12 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             return McpErrors.ProjectNotFound;
 
         PlayerMatSize? pmSize = null;
-        if (presetSize != null && !Enum.TryParse<PlayerMatSize>(presetSize, out var parsedSize))
-            return $"{{\"error\":\"Invalid PlayerMatSize '{presetSize}'\"}}";
-        else if (presetSize != null)
-            pmSize = Enum.Parse<PlayerMatSize>(presetSize);
+        if (presetSize != null)
+        {
+            if (!Enum.TryParse<PlayerMatSize>(presetSize, out var pmSizeParsed))
+                return $"{{\"error\":\"Invalid PlayerMatSize '{presetSize}'\"}}";
+            pmSize = pmSizeParsed;
+        }
 
         var mat = new PlayerMat
         {

--- a/src/Deckle.MCP/Tools/ComponentTools.cs
+++ b/src/Deckle.MCP/Tools/ComponentTools.cs
@@ -1,0 +1,314 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using ModelContextProtocol.Server;
+
+namespace Deckle.MCP.Tools;
+
+[McpServerToolType]
+public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpContextAccessor)
+{
+    private Guid UserId => GetUserId();
+
+    private Guid GetUserId()
+    {
+        var claim = httpContextAccessor.HttpContext?.User?.FindFirst("user_id")?.Value;
+        return Guid.TryParse(claim, out var id) ? id : throw new UnauthorizedAccessException("Not authenticated");
+    }
+
+    private async Task<bool> HasProjectAccessAsync(Guid projectId) =>
+        await db.UserProjects.AnyAsync(up => up.UserId == UserId && up.ProjectId == projectId);
+
+    [McpServerTool, Description("List all components in a project (cards, dice, game boards, player mats).")]
+    public async Task<string> ListComponents(
+        [Description("The project ID.")] Guid projectId)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        var components = await db.Components
+            .Where(c => c.ProjectId == projectId)
+            .Select(c => new
+            {
+                c.Id,
+                c.Name,
+                Type = EF.Property<string>(c, "ComponentType"),
+                c.CreatedAt,
+                c.UpdatedAt
+            })
+            .ToListAsync();
+
+        return JsonSerializer.Serialize(components);
+    }
+
+    [McpServerTool, Description("Get details of a specific component.")]
+    public async Task<string> GetComponent(
+        [Description("The component ID.")] Guid componentId)
+    {
+        var component = await db.Components
+            .Include(c => c.Project)
+            .FirstOrDefaultAsync(c => c.Id == componentId);
+
+        if (component == null || !component.ProjectId.HasValue)
+            return """{"error":"Component not found"}""";
+
+        if (!await HasProjectAccessAsync(component.ProjectId.Value))
+            return """{"error":"Access denied"}""";
+
+        return component switch
+        {
+            Card card => JsonSerializer.Serialize(new
+            {
+                card.Id, card.Name, Type = "Card",
+                Size = card.Size.ToString(), card.Horizontal,
+                card.ProjectId, card.CreatedAt, card.UpdatedAt
+            }),
+            Dice dice => JsonSerializer.Serialize(new
+            {
+                dice.Id, dice.Name, Type = "Dice",
+                DiceType = dice.Type.ToString(), Style = dice.Style.ToString(),
+                BaseColor = dice.BaseColor.ToString(), dice.Number,
+                dice.ProjectId, dice.CreatedAt, dice.UpdatedAt
+            }),
+            GameBoard board => JsonSerializer.Serialize(new
+            {
+                board.Id, board.Name, Type = "GameBoard",
+                PresetSize = board.PresetSize?.ToString(), board.Horizontal,
+                board.CustomWidthMm, board.CustomHeightMm,
+                board.ProjectId, board.CreatedAt, board.UpdatedAt
+            }),
+            PlayerMat mat => JsonSerializer.Serialize(new
+            {
+                mat.Id, mat.Name, Type = "PlayerMat",
+                PresetSize = mat.PresetSize?.ToString(), mat.Horizontal,
+                mat.CustomWidthMm, mat.CustomHeightMm,
+                mat.ProjectId, mat.CreatedAt, mat.UpdatedAt
+            }),
+            _ => JsonSerializer.Serialize(new { component.Id, component.Name, component.ProjectId })
+        };
+    }
+
+    [McpServerTool, Description($"Create a new card component. Valid sizes: MiniAmerican, MiniEuro, Bridge, MetricPoker, StandardPoker, Tarot, Jumbo, ExtraSmallSquare, SmallSquare, MediumSquare, LargeSquare.")]
+    public async Task<string> CreateCard(
+        [Description("The project ID.")] Guid projectId,
+        [Description("Card name.")] string name,
+        [Description("Card size (e.g. StandardPoker, Bridge, Tarot).")] string size = "StandardPoker",
+        [Description("Whether the card is horizontal (landscape). Default false = portrait.")] bool horizontal = false)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        if (!Enum.TryParse<CardSize>(size, out var cardSize))
+            return $"{{\"error\":\"Invalid card size '{size}'. Valid values: {string.Join(", ", Enum.GetNames<CardSize>())}\"}}";
+
+        var card = new Card
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            Name = name,
+            Size = cardSize,
+            Horizontal = horizontal,
+            Shape = new RectangleShape(3),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        db.Cards.Add(card);
+        await db.SaveChangesAsync();
+
+        return JsonSerializer.Serialize(new
+        {
+            card.Id, card.Name, Type = "Card",
+            Size = card.Size.ToString(), card.Horizontal,
+            card.ProjectId, card.CreatedAt
+        });
+    }
+
+    [McpServerTool, Description("Create a new dice component. DiceType: D4, D6, D8, D10, D12, D20. DiceStyle: Standard, Custom. DiceColor: White, Black, Red, Blue, Green, Yellow, Purple, Orange.")]
+    public async Task<string> CreateDice(
+        [Description("The project ID.")] Guid projectId,
+        [Description("Dice name.")] string name,
+        [Description("Dice type (e.g. D6, D20).")] string diceType = "D6",
+        [Description("Dice style.")] string style = "Standard",
+        [Description("Base color.")] string baseColor = "White",
+        [Description("Number of dice in the set.")] int number = 1)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        if (!Enum.TryParse<DiceType>(diceType, out var dt))
+            return $"{{\"error\":\"Invalid DiceType '{diceType}'\"}}";
+        if (!Enum.TryParse<DiceStyle>(style, out var ds))
+            return $"{{\"error\":\"Invalid DiceStyle '{style}'\"}}";
+        if (!Enum.TryParse<DiceColor>(baseColor, out var dc))
+            return $"{{\"error\":\"Invalid DiceColor '{baseColor}'\"}}";
+
+        var dice = new Dice
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            Name = name,
+            Type = dt,
+            Style = ds,
+            BaseColor = dc,
+            Number = number,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        db.Dices.Add(dice);
+        await db.SaveChangesAsync();
+
+        return JsonSerializer.Serialize(new
+        {
+            dice.Id, dice.Name, Type = "Dice",
+            DiceType = dice.Type.ToString(), Style = dice.Style.ToString(),
+            BaseColor = dice.BaseColor.ToString(), dice.Number,
+            dice.ProjectId, dice.CreatedAt
+        });
+    }
+
+    [McpServerTool, Description("Create a new game board component. PresetSize options include: MediumBifoldSquare, LargeQuadFoldSquare, MediumBifoldRectangle, etc. Omit presetSize to use custom dimensions.")]
+    public async Task<string> CreateGameBoard(
+        [Description("The project ID.")] Guid projectId,
+        [Description("Game board name.")] string name,
+        [Description("Preset size name (e.g. MediumBifoldSquare). Leave null for custom dimensions.")] string? presetSize = null,
+        [Description("Whether the board is horizontal (landscape).")] bool horizontal = true,
+        [Description("Custom width in mm (only used if presetSize is null).")] decimal? customWidthMm = null,
+        [Description("Custom height in mm (only used if presetSize is null).")] decimal? customHeightMm = null)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        GameBoardSize? gbSize = null;
+        if (presetSize != null && !Enum.TryParse<GameBoardSize>(presetSize, out var parsedSize))
+            return $"{{\"error\":\"Invalid GameBoardSize '{presetSize}'\"}}";
+        else if (presetSize != null)
+            gbSize = Enum.Parse<GameBoardSize>(presetSize);
+
+        var board = new GameBoard
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            Name = name,
+            PresetSize = gbSize,
+            Horizontal = horizontal,
+            CustomWidthMm = customWidthMm,
+            CustomHeightMm = customHeightMm,
+            Shape = new RectangleShape(0),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        db.GameBoards.Add(board);
+        await db.SaveChangesAsync();
+
+        return JsonSerializer.Serialize(new
+        {
+            board.Id, board.Name, Type = "GameBoard",
+            PresetSize = board.PresetSize?.ToString(), board.Horizontal,
+            board.ProjectId, board.CreatedAt
+        });
+    }
+
+    [McpServerTool, Description("Create a new player mat component. PresetSize options: A4, A3, Letter, Legal. Omit presetSize for custom dimensions.")]
+    public async Task<string> CreatePlayerMat(
+        [Description("The project ID.")] Guid projectId,
+        [Description("Player mat name.")] string name,
+        [Description("Preset size name (e.g. A4, Letter). Leave null for custom dimensions.")] string? presetSize = null,
+        [Description("Whether the mat is horizontal (landscape).")] bool horizontal = false,
+        [Description("Custom width in mm (only used if presetSize is null).")] decimal? customWidthMm = null,
+        [Description("Custom height in mm (only used if presetSize is null).")] decimal? customHeightMm = null)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        PlayerMatSize? pmSize = null;
+        if (presetSize != null && !Enum.TryParse<PlayerMatSize>(presetSize, out var parsedSize))
+            return $"{{\"error\":\"Invalid PlayerMatSize '{presetSize}'\"}}";
+        else if (presetSize != null)
+            pmSize = Enum.Parse<PlayerMatSize>(presetSize);
+
+        var mat = new PlayerMat
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            Name = name,
+            PresetSize = pmSize,
+            Horizontal = horizontal,
+            CustomWidthMm = customWidthMm,
+            CustomHeightMm = customHeightMm,
+            Shape = new RectangleShape(3),
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        db.PlayerMats.Add(mat);
+        await db.SaveChangesAsync();
+
+        return JsonSerializer.Serialize(new
+        {
+            mat.Id, mat.Name, Type = "PlayerMat",
+            PresetSize = mat.PresetSize?.ToString(), mat.Horizontal,
+            mat.ProjectId, mat.CreatedAt
+        });
+    }
+
+    [McpServerTool, Description("Delete a component from a project.")]
+    public async Task<string> DeleteComponent(
+        [Description("The component ID to delete.")] Guid componentId)
+    {
+        var component = await db.Components
+            .FirstOrDefaultAsync(c => c.Id == componentId);
+
+        if (component == null || !component.ProjectId.HasValue)
+            return """{"error":"Component not found"}""";
+
+        if (!await HasProjectAccessAsync(component.ProjectId.Value))
+            return """{"error":"Access denied"}""";
+
+        db.Components.Remove(component);
+        await db.SaveChangesAsync();
+        return """{"status":"deleted"}""";
+    }
+
+    [McpServerTool, Description("Link a data source to a component (card, game board, or player mat). Pass null dataSourceId to unlink.")]
+    public async Task<string> LinkDataSource(
+        [Description("The component ID.")] Guid componentId,
+        [Description("The data source ID to link, or null to unlink.")] Guid? dataSourceId)
+    {
+        var component = await db.Components
+            .FirstOrDefaultAsync(c => c.Id == componentId);
+
+        if (component == null || !component.ProjectId.HasValue)
+            return """{"error":"Component not found"}""";
+
+        if (!await HasProjectAccessAsync(component.ProjectId.Value))
+            return """{"error":"Access denied"}""";
+
+        if (component is not IDataSourceComponent dsc)
+            return """{"error":"This component type does not support data sources"}""";
+
+        if (dataSourceId.HasValue)
+        {
+            var dataSource = await db.DataSources
+                .FirstOrDefaultAsync(ds => ds.Id == dataSourceId.Value && ds.ProjectId == component.ProjectId);
+
+            if (dataSource == null)
+                return """{"error":"Data source not found in this project"}""";
+
+            dsc.DataSource = dataSource;
+        }
+        else
+        {
+            dsc.DataSource = null;
+        }
+
+        component.UpdatedAt = DateTime.UtcNow;
+        await db.SaveChangesAsync();
+        return JsonSerializer.Serialize(new { componentId, dataSourceId, Status = "updated" });
+    }
+}

--- a/src/Deckle.MCP/Tools/ComponentTools.cs
+++ b/src/Deckle.MCP/Tools/ComponentTools.cs
@@ -10,26 +10,16 @@ namespace Deckle.MCP.Tools;
 
 [McpServerToolType]
 public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpContextAccessor)
+    : BaseMcpTool(db, httpContextAccessor)
 {
-    private Guid UserId => GetUserId();
-
-    private Guid GetUserId()
-    {
-        var claim = httpContextAccessor.HttpContext?.User?.FindFirst("user_id")?.Value;
-        return Guid.TryParse(claim, out var id) ? id : throw new UnauthorizedAccessException("Not authenticated");
-    }
-
-    private async Task<bool> HasProjectAccessAsync(Guid projectId) =>
-        await db.UserProjects.AnyAsync(up => up.UserId == UserId && up.ProjectId == projectId);
-
     [McpServerTool, Description("List all components in a project (cards, dice, game boards, player mats).")]
     public async Task<string> ListComponents(
         [Description("The project ID.")] Guid projectId)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
-        var components = await db.Components
+        var components = await Db.Components
             .Where(c => c.ProjectId == projectId)
             .Select(c => new
             {
@@ -48,15 +38,15 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
     public async Task<string> GetComponent(
         [Description("The component ID.")] Guid componentId)
     {
-        var component = await db.Components
+        var component = await Db.Components
             .Include(c => c.Project)
             .FirstOrDefaultAsync(c => c.Id == componentId);
 
         if (component == null || !component.ProjectId.HasValue)
-            return """{"error":"Component not found"}""";
+            return McpErrors.ComponentNotFound;
 
         if (!await HasProjectAccessAsync(component.ProjectId.Value))
-            return """{"error":"Access denied"}""";
+            return McpErrors.AccessDenied;
 
         return component switch
         {
@@ -99,7 +89,7 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
         [Description("Whether the card is horizontal (landscape). Default false = portrait.")] bool horizontal = false)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
         if (!Enum.TryParse<CardSize>(size, out var cardSize))
             return $"{{\"error\":\"Invalid card size '{size}'. Valid values: {string.Join(", ", Enum.GetNames<CardSize>())}\"}}";
@@ -116,8 +106,8 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             UpdatedAt = DateTime.UtcNow
         };
 
-        db.Cards.Add(card);
-        await db.SaveChangesAsync();
+        Db.Cards.Add(card);
+        await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new
         {
@@ -137,7 +127,7 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
         [Description("Number of dice in the set.")] int number = 1)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
         if (!Enum.TryParse<DiceType>(diceType, out var dt))
             return $"{{\"error\":\"Invalid DiceType '{diceType}'\"}}";
@@ -159,8 +149,8 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             UpdatedAt = DateTime.UtcNow
         };
 
-        db.Dices.Add(dice);
-        await db.SaveChangesAsync();
+        Db.Dices.Add(dice);
+        await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new
         {
@@ -181,7 +171,7 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
         [Description("Custom height in mm (only used if presetSize is null).")] decimal? customHeightMm = null)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
         GameBoardSize? gbSize = null;
         if (presetSize != null && !Enum.TryParse<GameBoardSize>(presetSize, out var parsedSize))
@@ -203,8 +193,8 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             UpdatedAt = DateTime.UtcNow
         };
 
-        db.GameBoards.Add(board);
-        await db.SaveChangesAsync();
+        Db.GameBoards.Add(board);
+        await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new
         {
@@ -224,7 +214,7 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
         [Description("Custom height in mm (only used if presetSize is null).")] decimal? customHeightMm = null)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
         PlayerMatSize? pmSize = null;
         if (presetSize != null && !Enum.TryParse<PlayerMatSize>(presetSize, out var parsedSize))
@@ -246,8 +236,8 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             UpdatedAt = DateTime.UtcNow
         };
 
-        db.PlayerMats.Add(mat);
-        await db.SaveChangesAsync();
+        Db.PlayerMats.Add(mat);
+        await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new
         {
@@ -261,18 +251,18 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
     public async Task<string> DeleteComponent(
         [Description("The component ID to delete.")] Guid componentId)
     {
-        var component = await db.Components
+        var component = await Db.Components
             .FirstOrDefaultAsync(c => c.Id == componentId);
 
         if (component == null || !component.ProjectId.HasValue)
-            return """{"error":"Component not found"}""";
+            return McpErrors.ComponentNotFound;
 
         if (!await HasProjectAccessAsync(component.ProjectId.Value))
-            return """{"error":"Access denied"}""";
+            return McpErrors.AccessDenied;
 
-        db.Components.Remove(component);
-        await db.SaveChangesAsync();
-        return """{"status":"deleted"}""";
+        Db.Components.Remove(component);
+        await Db.SaveChangesAsync();
+        return McpErrors.Deleted;
     }
 
     [McpServerTool, Description("Link a data source to a component (card, game board, or player mat). Pass null dataSourceId to unlink.")]
@@ -280,21 +270,21 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
         [Description("The component ID.")] Guid componentId,
         [Description("The data source ID to link, or null to unlink.")] Guid? dataSourceId)
     {
-        var component = await db.Components
+        var component = await Db.Components
             .FirstOrDefaultAsync(c => c.Id == componentId);
 
         if (component == null || !component.ProjectId.HasValue)
-            return """{"error":"Component not found"}""";
+            return McpErrors.ComponentNotFound;
 
         if (!await HasProjectAccessAsync(component.ProjectId.Value))
-            return """{"error":"Access denied"}""";
+            return McpErrors.AccessDenied;
 
         if (component is not IDataSourceComponent dsc)
             return """{"error":"This component type does not support data sources"}""";
 
         if (dataSourceId.HasValue)
         {
-            var dataSource = await db.DataSources
+            var dataSource = await Db.DataSources
                 .FirstOrDefaultAsync(ds => ds.Id == dataSourceId.Value && ds.ProjectId == component.ProjectId);
 
             if (dataSource == null)
@@ -308,7 +298,7 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
         }
 
         component.UpdatedAt = DateTime.UtcNow;
-        await db.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         return JsonSerializer.Serialize(new { componentId, dataSourceId, Status = "updated" });
     }
 }

--- a/src/Deckle.MCP/Tools/ComponentTools.cs
+++ b/src/Deckle.MCP/Tools/ComponentTools.cs
@@ -106,7 +106,7 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             UpdatedAt = DateTime.UtcNow
         };
 
-        Db.Cards.Add(card);
+        await Db.Cards.AddAsync(card);
         await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new
@@ -149,7 +149,7 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             UpdatedAt = DateTime.UtcNow
         };
 
-        Db.Dices.Add(dice);
+        await Db.Dices.AddAsync(dice);
         await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new
@@ -193,7 +193,7 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             UpdatedAt = DateTime.UtcNow
         };
 
-        Db.GameBoards.Add(board);
+        await Db.GameBoards.AddAsync(board);
         await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new
@@ -236,7 +236,7 @@ public sealed class ComponentTools(AppDbContext db, IHttpContextAccessor httpCon
             UpdatedAt = DateTime.UtcNow
         };
 
-        Db.PlayerMats.Add(mat);
+        await Db.PlayerMats.AddAsync(mat);
         await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new

--- a/src/Deckle.MCP/Tools/DataSourceTools.cs
+++ b/src/Deckle.MCP/Tools/DataSourceTools.cs
@@ -11,26 +11,16 @@ namespace Deckle.MCP.Tools;
 
 [McpServerToolType]
 public sealed class DataSourceTools(AppDbContext db, IHttpContextAccessor httpContextAccessor)
+    : BaseMcpTool(db, httpContextAccessor)
 {
-    private Guid UserId => GetUserId();
-
-    private Guid GetUserId()
-    {
-        var claim = httpContextAccessor.HttpContext?.User?.FindFirst("user_id")?.Value;
-        return Guid.TryParse(claim, out var id) ? id : throw new UnauthorizedAccessException("Not authenticated");
-    }
-
-    private async Task<bool> HasProjectAccessAsync(Guid projectId) =>
-        await db.UserProjects.AnyAsync(up => up.UserId == UserId && up.ProjectId == projectId);
-
     [McpServerTool, Description("List all data sources in a project.")]
     public async Task<string> ListDataSources(
         [Description("The project ID.")] Guid projectId)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
-        var sources = await db.DataSources
+        var sources = await Db.DataSources
             .Where(ds => ds.ProjectId == projectId)
             .Select(ds => new
             {
@@ -51,13 +41,13 @@ public sealed class DataSourceTools(AppDbContext db, IHttpContextAccessor httpCo
     public async Task<string> GetDataSource(
         [Description("The data source ID.")] Guid dataSourceId)
     {
-        var ds = await db.DataSources.FirstOrDefaultAsync(d => d.Id == dataSourceId);
+        var ds = await Db.DataSources.FirstOrDefaultAsync(d => d.Id == dataSourceId);
 
         if (ds == null)
-            return """{"error":"Data source not found"}""";
+            return McpErrors.DataSourceNotFound;
 
         if (ds.ProjectId.HasValue && !await HasProjectAccessAsync(ds.ProjectId.Value))
-            return """{"error":"Access denied"}""";
+            return McpErrors.AccessDenied;
 
         if (ds is GoogleSheetsDataSource gs)
         {
@@ -84,7 +74,7 @@ public sealed class DataSourceTools(AppDbContext db, IHttpContextAccessor httpCo
         [Description("The full Google Sheets URL (e.g. https://docs.google.com/spreadsheets/d/SHEET_ID/edit#gid=0).")] string googleSheetsUrl)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
         if (!Uri.TryCreate(googleSheetsUrl, UriKind.Absolute, out var uri))
             return """{"error":"Invalid Google Sheets URL"}""";
@@ -110,8 +100,8 @@ public sealed class DataSourceTools(AppDbContext db, IHttpContextAccessor httpCo
             UpdatedAt = DateTime.UtcNow
         };
 
-        db.GoogleSheetsDataSources.Add(ds);
-        await db.SaveChangesAsync();
+        Db.GoogleSheetsDataSources.Add(ds);
+        await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new
         {
@@ -129,19 +119,19 @@ public sealed class DataSourceTools(AppDbContext db, IHttpContextAccessor httpCo
         [Description("List of column header names.")] List<string> headers,
         [Description("Number of data rows (excluding the header row).")] int rowCount)
     {
-        var ds = await db.DataSources.FirstOrDefaultAsync(d => d.Id == dataSourceId);
+        var ds = await Db.DataSources.FirstOrDefaultAsync(d => d.Id == dataSourceId);
 
         if (ds == null)
-            return """{"error":"Data source not found"}""";
+            return McpErrors.DataSourceNotFound;
 
         if (ds.ProjectId.HasValue && !await HasProjectAccessAsync(ds.ProjectId.Value))
-            return """{"error":"Access denied"}""";
+            return McpErrors.AccessDenied;
 
         ds.Headers = headers;
         ds.RowCount = rowCount;
         ds.UpdatedAt = DateTime.UtcNow;
 
-        await db.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         return JsonSerializer.Serialize(new { ds.Id, ds.Name, ds.Headers, ds.RowCount, Status = "synced" });
     }
 
@@ -149,17 +139,17 @@ public sealed class DataSourceTools(AppDbContext db, IHttpContextAccessor httpCo
     public async Task<string> DeleteDataSource(
         [Description("The data source ID to delete.")] Guid dataSourceId)
     {
-        var ds = await db.DataSources.FirstOrDefaultAsync(d => d.Id == dataSourceId);
+        var ds = await Db.DataSources.FirstOrDefaultAsync(d => d.Id == dataSourceId);
 
         if (ds == null)
-            return """{"error":"Data source not found"}""";
+            return McpErrors.DataSourceNotFound;
 
         if (!ds.ProjectId.HasValue || !await HasProjectAccessAsync(ds.ProjectId.Value))
-            return """{"error":"Access denied"}""";
+            return McpErrors.AccessDenied;
 
-        db.DataSources.Remove(ds);
-        await db.SaveChangesAsync();
-        return """{"status":"deleted"}""";
+        Db.DataSources.Remove(ds);
+        await Db.SaveChangesAsync();
+        return McpErrors.Deleted;
     }
 
     private static (string? spreadsheetId, int? sheetGid) ExtractGoogleSheetsIds(Uri url)

--- a/src/Deckle.MCP/Tools/DataSourceTools.cs
+++ b/src/Deckle.MCP/Tools/DataSourceTools.cs
@@ -100,7 +100,7 @@ public sealed class DataSourceTools(AppDbContext db, IHttpContextAccessor httpCo
             UpdatedAt = DateTime.UtcNow
         };
 
-        Db.GoogleSheetsDataSources.Add(ds);
+        await Db.GoogleSheetsDataSources.AddAsync(ds);
         await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new

--- a/src/Deckle.MCP/Tools/DataSourceTools.cs
+++ b/src/Deckle.MCP/Tools/DataSourceTools.cs
@@ -1,0 +1,184 @@
+using System.ComponentModel;
+using System.Text.Json;
+using System.Text.RegularExpressions;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using ModelContextProtocol.Server;
+
+namespace Deckle.MCP.Tools;
+
+[McpServerToolType]
+public sealed class DataSourceTools(AppDbContext db, IHttpContextAccessor httpContextAccessor)
+{
+    private Guid UserId => GetUserId();
+
+    private Guid GetUserId()
+    {
+        var claim = httpContextAccessor.HttpContext?.User?.FindFirst("user_id")?.Value;
+        return Guid.TryParse(claim, out var id) ? id : throw new UnauthorizedAccessException("Not authenticated");
+    }
+
+    private async Task<bool> HasProjectAccessAsync(Guid projectId) =>
+        await db.UserProjects.AnyAsync(up => up.UserId == UserId && up.ProjectId == projectId);
+
+    [McpServerTool, Description("List all data sources in a project.")]
+    public async Task<string> ListDataSources(
+        [Description("The project ID.")] Guid projectId)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        var sources = await db.DataSources
+            .Where(ds => ds.ProjectId == projectId)
+            .Select(ds => new
+            {
+                ds.Id,
+                ds.Name,
+                Type = ds.Type.ToString(),
+                ds.RowCount,
+                ds.Headers,
+                ds.CreatedAt,
+                ds.UpdatedAt
+            })
+            .ToListAsync();
+
+        return JsonSerializer.Serialize(sources);
+    }
+
+    [McpServerTool, Description("Get details of a specific data source, including its headers and row count.")]
+    public async Task<string> GetDataSource(
+        [Description("The data source ID.")] Guid dataSourceId)
+    {
+        var ds = await db.DataSources.FirstOrDefaultAsync(d => d.Id == dataSourceId);
+
+        if (ds == null)
+            return """{"error":"Data source not found"}""";
+
+        if (ds.ProjectId.HasValue && !await HasProjectAccessAsync(ds.ProjectId.Value))
+            return """{"error":"Access denied"}""";
+
+        if (ds is GoogleSheetsDataSource gs)
+        {
+            return JsonSerializer.Serialize(new
+            {
+                gs.Id, gs.Name, Type = "GoogleSheets",
+                gs.GoogleSheetsId, GoogleSheetsUrl = gs.GoogleSheetsUrl?.ToString(),
+                gs.SheetGid, CsvExportUrl = gs.CsvExportUrl?.ToString(),
+                gs.Headers, gs.RowCount, gs.ProjectId, gs.CreatedAt, gs.UpdatedAt
+            });
+        }
+
+        return JsonSerializer.Serialize(new
+        {
+            ds.Id, ds.Name, Type = ds.Type.ToString(),
+            ds.Headers, ds.RowCount, ds.ProjectId, ds.CreatedAt, ds.UpdatedAt
+        });
+    }
+
+    [McpServerTool, Description("Create a Google Sheets data source linked to a project. The sheet must be publicly accessible ('Anyone with the link can view').")]
+    public async Task<string> CreateGoogleSheetsDataSource(
+        [Description("The project ID.")] Guid projectId,
+        [Description("A display name for this data source.")] string name,
+        [Description("The full Google Sheets URL (e.g. https://docs.google.com/spreadsheets/d/SHEET_ID/edit#gid=0).")] string googleSheetsUrl)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        if (!Uri.TryCreate(googleSheetsUrl, UriKind.Absolute, out var uri))
+            return """{"error":"Invalid Google Sheets URL"}""";
+
+        var (spreadsheetId, sheetGid) = ExtractGoogleSheetsIds(uri);
+        if (string.IsNullOrEmpty(spreadsheetId))
+            return """{"error":"Could not extract spreadsheet ID from URL"}""";
+
+        var finalGid = sheetGid ?? 0;
+        var csvExportUrl = new Uri($"https://docs.google.com/spreadsheets/d/{spreadsheetId}/export?format=csv&gid={finalGid}");
+
+        var ds = new GoogleSheetsDataSource
+        {
+            Id = Guid.NewGuid(),
+            ProjectId = projectId,
+            Name = name,
+            Type = DataSourceType.GoogleSheets,
+            GoogleSheetsId = spreadsheetId,
+            GoogleSheetsUrl = uri,
+            SheetGid = finalGid,
+            CsvExportUrl = csvExportUrl,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        db.GoogleSheetsDataSources.Add(ds);
+        await db.SaveChangesAsync();
+
+        return JsonSerializer.Serialize(new
+        {
+            ds.Id, ds.Name, Type = "GoogleSheets",
+            ds.GoogleSheetsId, GoogleSheetsUrl = ds.GoogleSheetsUrl.ToString(),
+            ds.SheetGid, CsvExportUrl = ds.CsvExportUrl.ToString(),
+            ds.ProjectId, ds.CreatedAt,
+            Note = "Use sync_data_source to populate headers and row count after creation."
+        });
+    }
+
+    [McpServerTool, Description("Update the metadata (headers and row count) of a data source. For Google Sheets sources, provide the latest column headers and number of data rows.")]
+    public async Task<string> SyncDataSourceMetadata(
+        [Description("The data source ID.")] Guid dataSourceId,
+        [Description("List of column header names.")] List<string> headers,
+        [Description("Number of data rows (excluding the header row).")] int rowCount)
+    {
+        var ds = await db.DataSources.FirstOrDefaultAsync(d => d.Id == dataSourceId);
+
+        if (ds == null)
+            return """{"error":"Data source not found"}""";
+
+        if (ds.ProjectId.HasValue && !await HasProjectAccessAsync(ds.ProjectId.Value))
+            return """{"error":"Access denied"}""";
+
+        ds.Headers = headers;
+        ds.RowCount = rowCount;
+        ds.UpdatedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync();
+        return JsonSerializer.Serialize(new { ds.Id, ds.Name, ds.Headers, ds.RowCount, Status = "synced" });
+    }
+
+    [McpServerTool, Description("Delete a data source from a project.")]
+    public async Task<string> DeleteDataSource(
+        [Description("The data source ID to delete.")] Guid dataSourceId)
+    {
+        var ds = await db.DataSources.FirstOrDefaultAsync(d => d.Id == dataSourceId);
+
+        if (ds == null)
+            return """{"error":"Data source not found"}""";
+
+        if (!ds.ProjectId.HasValue || !await HasProjectAccessAsync(ds.ProjectId.Value))
+            return """{"error":"Access denied"}""";
+
+        db.DataSources.Remove(ds);
+        await db.SaveChangesAsync();
+        return """{"status":"deleted"}""";
+    }
+
+    private static (string? spreadsheetId, int? sheetGid) ExtractGoogleSheetsIds(Uri url)
+    {
+        string? spreadsheetId = null;
+        int? sheetGid = null;
+
+        var urlStr = url.ToString();
+
+        foreach (var pattern in new[] { @"docs\.google\.com/spreadsheets/d/([a-zA-Z0-9-_]+)", @"spreadsheets/d/([a-zA-Z0-9-_]+)" })
+        {
+            var match = Regex.Match(urlStr, pattern);
+            if (match.Success) { spreadsheetId = match.Groups[1].Value; break; }
+        }
+
+        var gidMatch = Regex.Match(urlStr, @"[#?&]gid=(\d+)");
+        if (gidMatch.Success && int.TryParse(gidMatch.Groups[1].Value, out var parsedGid))
+            sheetGid = parsedGid;
+
+        return (spreadsheetId, sheetGid);
+    }
+}

--- a/src/Deckle.MCP/Tools/DataSourceTools.cs
+++ b/src/Deckle.MCP/Tools/DataSourceTools.cs
@@ -159,13 +159,14 @@ public sealed class DataSourceTools(AppDbContext db, IHttpContextAccessor httpCo
 
         var urlStr = url.ToString();
 
+        var timeout = TimeSpan.FromSeconds(1);
         foreach (var pattern in new[] { @"docs\.google\.com/spreadsheets/d/([a-zA-Z0-9-_]+)", @"spreadsheets/d/([a-zA-Z0-9-_]+)" })
         {
-            var match = Regex.Match(urlStr, pattern);
+            var match = Regex.Match(urlStr, pattern, RegexOptions.None, timeout);
             if (match.Success) { spreadsheetId = match.Groups[1].Value; break; }
         }
 
-        var gidMatch = Regex.Match(urlStr, @"[#?&]gid=(\d+)");
+        var gidMatch = Regex.Match(urlStr, @"[#?&]gid=(\d+)", RegexOptions.None, timeout);
         if (gidMatch.Success && int.TryParse(gidMatch.Groups[1].Value, out var parsedGid))
             sheetGid = parsedGid;
 

--- a/src/Deckle.MCP/Tools/FileTools.cs
+++ b/src/Deckle.MCP/Tools/FileTools.cs
@@ -1,0 +1,94 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Deckle.Domain.Data;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using ModelContextProtocol.Server;
+
+namespace Deckle.MCP.Tools;
+
+[McpServerToolType]
+public sealed class FileTools(AppDbContext db, IHttpContextAccessor httpContextAccessor)
+{
+    private Guid UserId => GetUserId();
+
+    private Guid GetUserId()
+    {
+        var claim = httpContextAccessor.HttpContext?.User?.FindFirst("user_id")?.Value;
+        return Guid.TryParse(claim, out var id) ? id : throw new UnauthorizedAccessException("Not authenticated");
+    }
+
+    private async Task<bool> HasProjectAccessAsync(Guid projectId) =>
+        await db.UserProjects.AnyAsync(up => up.UserId == UserId && up.ProjectId == projectId);
+
+    [McpServerTool, Description("List all files in a project, optionally filtered by tag.")]
+    public async Task<string> ListFiles(
+        [Description("The project ID.")] Guid projectId,
+        [Description("Optional tag to filter files by.")] string? tag = null)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        var query = db.Files
+            .Where(f => f.ProjectId == projectId &&
+                        f.Status == Deckle.Domain.Entities.FileStatus.Confirmed);
+
+        if (tag != null)
+            query = query.Where(f => f.Tags.Contains(tag));
+
+        var files = await query
+            .Select(f => new
+            {
+                f.Id,
+                f.FileName,
+                f.Path,
+                f.ContentType,
+                f.Tags,
+                f.DirectoryId,
+                f.UploadedAt
+            })
+            .OrderBy(f => f.Path)
+            .ToListAsync();
+
+        return JsonSerializer.Serialize(files);
+    }
+
+    [McpServerTool, Description("List all directories in a project.")]
+    public async Task<string> ListDirectories(
+        [Description("The project ID.")] Guid projectId)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        var dirs = await db.FileDirectories
+            .Where(d => d.ProjectId == projectId)
+            .Select(d => new
+            {
+                d.Id,
+                d.Name,
+                d.ParentDirectoryId,
+                d.CreatedAt
+            })
+            .OrderBy(d => d.Name)
+            .ToListAsync();
+
+        return JsonSerializer.Serialize(dirs);
+    }
+
+    [McpServerTool, Description("List tags used across all files in a project.")]
+    public async Task<string> ListFileTags(
+        [Description("The project ID.")] Guid projectId)
+    {
+        if (!await HasProjectAccessAsync(projectId))
+            return """{"error":"Project not found"}""";
+
+        var tags = await db.Files
+            .Where(f => f.ProjectId == projectId && f.Status == Deckle.Domain.Entities.FileStatus.Confirmed)
+            .SelectMany(f => f.Tags)
+            .Distinct()
+            .OrderBy(t => t)
+            .ToListAsync();
+
+        return JsonSerializer.Serialize(tags);
+    }
+}

--- a/src/Deckle.MCP/Tools/FileTools.cs
+++ b/src/Deckle.MCP/Tools/FileTools.cs
@@ -72,13 +72,12 @@ public sealed class FileTools(AppDbContext db, IHttpContextAccessor httpContextA
         if (!await HasProjectAccessAsync(projectId))
             return McpErrors.ProjectNotFound;
 
-        var tags = await Db.Files
+        var tagLists = await Db.Files
             .Where(f => f.ProjectId == projectId && f.Status == Deckle.Domain.Entities.FileStatus.Confirmed)
-            .SelectMany(f => f.Tags)
-            .Distinct()
-            .OrderBy(t => t)
+            .Select(f => f.Tags)
             .ToListAsync();
 
+        var tags = tagLists.SelectMany(t => t).Distinct().OrderBy(t => t).ToList();
         return JsonSerializer.Serialize(tags);
     }
 }

--- a/src/Deckle.MCP/Tools/FileTools.cs
+++ b/src/Deckle.MCP/Tools/FileTools.cs
@@ -9,27 +9,17 @@ namespace Deckle.MCP.Tools;
 
 [McpServerToolType]
 public sealed class FileTools(AppDbContext db, IHttpContextAccessor httpContextAccessor)
+    : BaseMcpTool(db, httpContextAccessor)
 {
-    private Guid UserId => GetUserId();
-
-    private Guid GetUserId()
-    {
-        var claim = httpContextAccessor.HttpContext?.User?.FindFirst("user_id")?.Value;
-        return Guid.TryParse(claim, out var id) ? id : throw new UnauthorizedAccessException("Not authenticated");
-    }
-
-    private async Task<bool> HasProjectAccessAsync(Guid projectId) =>
-        await db.UserProjects.AnyAsync(up => up.UserId == UserId && up.ProjectId == projectId);
-
     [McpServerTool, Description("List all files in a project, optionally filtered by tag.")]
     public async Task<string> ListFiles(
         [Description("The project ID.")] Guid projectId,
         [Description("Optional tag to filter files by.")] string? tag = null)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
-        var query = db.Files
+        var query = Db.Files
             .Where(f => f.ProjectId == projectId &&
                         f.Status == Deckle.Domain.Entities.FileStatus.Confirmed);
 
@@ -58,9 +48,9 @@ public sealed class FileTools(AppDbContext db, IHttpContextAccessor httpContextA
         [Description("The project ID.")] Guid projectId)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
-        var dirs = await db.FileDirectories
+        var dirs = await Db.FileDirectories
             .Where(d => d.ProjectId == projectId)
             .Select(d => new
             {
@@ -80,9 +70,9 @@ public sealed class FileTools(AppDbContext db, IHttpContextAccessor httpContextA
         [Description("The project ID.")] Guid projectId)
     {
         if (!await HasProjectAccessAsync(projectId))
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
-        var tags = await db.Files
+        var tags = await Db.Files
             .Where(f => f.ProjectId == projectId && f.Status == Deckle.Domain.Entities.FileStatus.Confirmed)
             .SelectMany(f => f.Tags)
             .Distinct()

--- a/src/Deckle.MCP/Tools/McpErrors.cs
+++ b/src/Deckle.MCP/Tools/McpErrors.cs
@@ -1,0 +1,11 @@
+namespace Deckle.MCP.Tools;
+
+internal static class McpErrors
+{
+    public const string ProjectNotFound = """{"error":"Project not found"}""";
+    public const string ProjectNotFoundOrNotOwner = """{"error":"Project not found or you are not the owner"}""";
+    public const string AccessDenied = """{"error":"Access denied"}""";
+    public const string ComponentNotFound = """{"error":"Component not found"}""";
+    public const string DataSourceNotFound = """{"error":"Data source not found"}""";
+    public const string Deleted = """{"status":"deleted"}""";
+}

--- a/src/Deckle.MCP/Tools/ProjectTools.cs
+++ b/src/Deckle.MCP/Tools/ProjectTools.cs
@@ -1,0 +1,195 @@
+using System.ComponentModel;
+using System.Text.Json;
+using Deckle.Domain.Data;
+using Deckle.Domain.Entities;
+using Microsoft.AspNetCore.Http;
+using Microsoft.EntityFrameworkCore;
+using ModelContextProtocol.Server;
+
+namespace Deckle.MCP.Tools;
+
+[McpServerToolType]
+public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpContextAccessor)
+{
+    private Guid UserId => GetUserId();
+
+    private Guid GetUserId()
+    {
+        var claim = httpContextAccessor.HttpContext?.User?.FindFirst("user_id")?.Value;
+        return Guid.TryParse(claim, out var id) ? id : throw new UnauthorizedAccessException("Not authenticated");
+    }
+
+    [McpServerTool, Description("List all projects the authenticated user has access to.")]
+    public async Task<string> ListProjects()
+    {
+        var projects = await db.UserProjects
+            .Where(up => up.UserId == UserId)
+            .Join(
+                db.UserProjects.Where(ownerUp => ownerUp.Role == ProjectRole.Owner),
+                up => up.ProjectId,
+                ownerUp => ownerUp.ProjectId,
+                (up, ownerUp) => new
+                {
+                    up.Project.Id,
+                    up.Project.Name,
+                    up.Project.Code,
+                    up.Project.Description,
+                    Visibility = up.Project.Visibility.ToString(),
+                    up.Project.CreatedAt,
+                    up.Project.UpdatedAt,
+                    Role = up.Role.ToString(),
+                    OwnerUsername = ownerUp.User.Username ?? string.Empty
+                })
+            .ToListAsync();
+
+        return JsonSerializer.Serialize(projects);
+    }
+
+    [McpServerTool, Description("Get a specific project by its ID.")]
+    public async Task<string> GetProject(
+        [Description("The project ID (GUID).")] Guid projectId)
+    {
+        var project = await db.UserProjects
+            .Where(up => up.UserId == UserId && up.ProjectId == projectId)
+            .Join(
+                db.UserProjects.Where(ownerUp => ownerUp.Role == ProjectRole.Owner),
+                up => up.ProjectId,
+                ownerUp => ownerUp.ProjectId,
+                (up, ownerUp) => new
+                {
+                    up.Project.Id,
+                    up.Project.Name,
+                    up.Project.Code,
+                    up.Project.Description,
+                    Visibility = up.Project.Visibility.ToString(),
+                    up.Project.CreatedAt,
+                    up.Project.UpdatedAt,
+                    Role = up.Role.ToString(),
+                    OwnerUsername = ownerUp.User.Username ?? string.Empty
+                })
+            .FirstOrDefaultAsync();
+
+        return project == null
+            ? """{"error":"Project not found"}"""
+            : JsonSerializer.Serialize(project);
+    }
+
+    [McpServerTool, Description("Create a new project. The code must be unique per user and contain only lowercase letters, numbers, and dashes.")]
+    public async Task<string> CreateProject(
+        [Description("Human-readable project name (max 100 chars).")] string name,
+        [Description("URL-safe project code (lowercase letters, numbers, dashes; max 50 chars).")] string code,
+        [Description("Optional project description.")] string? description = null,
+        [Description("Visibility: Private, Public, or Teaser. Defaults to Private.")] string visibility = "Private")
+    {
+        if (!Enum.TryParse<ProjectVisibility>(visibility, out var vis))
+            vis = ProjectVisibility.Private;
+
+        var user = await db.Users.FindAsync(UserId);
+        var ownerUsername = user?.Username ?? string.Empty;
+
+        var project = new Project
+        {
+            Id = Guid.NewGuid(),
+            Name = name,
+            Code = code,
+            Description = description,
+            Visibility = vis,
+            CreatedAt = DateTime.UtcNow,
+            UpdatedAt = DateTime.UtcNow
+        };
+
+        db.Projects.Add(project);
+        db.UserProjects.Add(new UserProject
+        {
+            UserId = UserId,
+            ProjectId = project.Id,
+            Role = ProjectRole.Owner,
+            JoinedAt = DateTime.UtcNow
+        });
+
+        await db.SaveChangesAsync();
+
+        return JsonSerializer.Serialize(new
+        {
+            project.Id,
+            project.Name,
+            project.Code,
+            project.Description,
+            Visibility = project.Visibility.ToString(),
+            project.CreatedAt,
+            project.UpdatedAt,
+            Role = "Owner",
+            OwnerUsername = ownerUsername
+        });
+    }
+
+    [McpServerTool, Description("Update a project's name, description, or visibility.")]
+    public async Task<string> UpdateProject(
+        [Description("The project ID to update.")] Guid projectId,
+        [Description("New project name.")] string name,
+        [Description("New description (or null to clear).")] string? description = null,
+        [Description("New visibility: Private, Public, or Teaser.")] string visibility = "Private")
+    {
+        var userProject = await db.UserProjects
+            .Include(up => up.Project)
+            .FirstOrDefaultAsync(up => up.UserId == UserId && up.ProjectId == projectId
+                && up.Role == ProjectRole.Owner);
+
+        if (userProject == null)
+            return """{"error":"Project not found or you are not the owner"}""";
+
+        if (!Enum.TryParse<ProjectVisibility>(visibility, out var vis))
+            vis = ProjectVisibility.Private;
+
+        userProject.Project.Name = name;
+        userProject.Project.Description = description;
+        userProject.Project.Visibility = vis;
+        userProject.Project.UpdatedAt = DateTime.UtcNow;
+
+        await db.SaveChangesAsync();
+        return JsonSerializer.Serialize(new { userProject.Project.Id, userProject.Project.Name, Status = "updated" });
+    }
+
+    [McpServerTool, Description("Delete a project. You must be the project owner.")]
+    public async Task<string> DeleteProject(
+        [Description("The project ID to delete.")] Guid projectId)
+    {
+        var userProject = await db.UserProjects
+            .Include(up => up.Project)
+            .FirstOrDefaultAsync(up => up.UserId == UserId && up.ProjectId == projectId
+                && up.Role == ProjectRole.Owner);
+
+        if (userProject == null)
+            return """{"error":"Project not found or you are not the owner"}""";
+
+        db.Projects.Remove(userProject.Project);
+        await db.SaveChangesAsync();
+        return """{"status":"deleted"}""";
+    }
+
+    [McpServerTool, Description("List all members of a project.")]
+    public async Task<string> ListProjectMembers(
+        [Description("The project ID.")] Guid projectId)
+    {
+        var hasAccess = await db.UserProjects
+            .AnyAsync(up => up.UserId == UserId && up.ProjectId == projectId);
+
+        if (!hasAccess)
+            return """{"error":"Project not found"}""";
+
+        var members = await db.UserProjects
+            .Where(up => up.ProjectId == projectId)
+            .Select(up => new
+            {
+                up.UserId,
+                up.User.Email,
+                up.User.Username,
+                up.User.Name,
+                Role = up.Role.ToString(),
+                up.JoinedAt
+            })
+            .ToListAsync();
+
+        return JsonSerializer.Serialize(members);
+    }
+}

--- a/src/Deckle.MCP/Tools/ProjectTools.cs
+++ b/src/Deckle.MCP/Tools/ProjectTools.cs
@@ -10,22 +10,15 @@ namespace Deckle.MCP.Tools;
 
 [McpServerToolType]
 public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpContextAccessor)
+    : BaseMcpTool(db, httpContextAccessor)
 {
-    private Guid UserId => GetUserId();
-
-    private Guid GetUserId()
-    {
-        var claim = httpContextAccessor.HttpContext?.User?.FindFirst("user_id")?.Value;
-        return Guid.TryParse(claim, out var id) ? id : throw new UnauthorizedAccessException("Not authenticated");
-    }
-
     [McpServerTool, Description("List all projects the authenticated user has access to.")]
     public async Task<string> ListProjects()
     {
-        var projects = await db.UserProjects
+        var projects = await Db.UserProjects
             .Where(up => up.UserId == UserId)
             .Join(
-                db.UserProjects.Where(ownerUp => ownerUp.Role == ProjectRole.Owner),
+                Db.UserProjects.Where(ownerUp => ownerUp.Role == ProjectRole.Owner),
                 up => up.ProjectId,
                 ownerUp => ownerUp.ProjectId,
                 (up, ownerUp) => new
@@ -49,10 +42,10 @@ public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpConte
     public async Task<string> GetProject(
         [Description("The project ID (GUID).")] Guid projectId)
     {
-        var project = await db.UserProjects
+        var project = await Db.UserProjects
             .Where(up => up.UserId == UserId && up.ProjectId == projectId)
             .Join(
-                db.UserProjects.Where(ownerUp => ownerUp.Role == ProjectRole.Owner),
+                Db.UserProjects.Where(ownerUp => ownerUp.Role == ProjectRole.Owner),
                 up => up.ProjectId,
                 ownerUp => ownerUp.ProjectId,
                 (up, ownerUp) => new
@@ -70,7 +63,7 @@ public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpConte
             .FirstOrDefaultAsync();
 
         return project == null
-            ? """{"error":"Project not found"}"""
+            ? McpErrors.ProjectNotFound
             : JsonSerializer.Serialize(project);
     }
 
@@ -84,7 +77,7 @@ public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpConte
         if (!Enum.TryParse<ProjectVisibility>(visibility, out var vis))
             vis = ProjectVisibility.Private;
 
-        var user = await db.Users.FindAsync(UserId);
+        var user = await Db.Users.FindAsync(UserId);
         var ownerUsername = user?.Username ?? string.Empty;
 
         var project = new Project
@@ -98,8 +91,8 @@ public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpConte
             UpdatedAt = DateTime.UtcNow
         };
 
-        db.Projects.Add(project);
-        db.UserProjects.Add(new UserProject
+        Db.Projects.Add(project);
+        Db.UserProjects.Add(new UserProject
         {
             UserId = UserId,
             ProjectId = project.Id,
@@ -107,7 +100,7 @@ public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpConte
             JoinedAt = DateTime.UtcNow
         });
 
-        await db.SaveChangesAsync();
+        await Db.SaveChangesAsync();
 
         return JsonSerializer.Serialize(new
         {
@@ -130,13 +123,13 @@ public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpConte
         [Description("New description (or null to clear).")] string? description = null,
         [Description("New visibility: Private, Public, or Teaser.")] string visibility = "Private")
     {
-        var userProject = await db.UserProjects
+        var userProject = await Db.UserProjects
             .Include(up => up.Project)
             .FirstOrDefaultAsync(up => up.UserId == UserId && up.ProjectId == projectId
                 && up.Role == ProjectRole.Owner);
 
         if (userProject == null)
-            return """{"error":"Project not found or you are not the owner"}""";
+            return McpErrors.ProjectNotFoundOrNotOwner;
 
         if (!Enum.TryParse<ProjectVisibility>(visibility, out var vis))
             vis = ProjectVisibility.Private;
@@ -146,7 +139,7 @@ public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpConte
         userProject.Project.Visibility = vis;
         userProject.Project.UpdatedAt = DateTime.UtcNow;
 
-        await db.SaveChangesAsync();
+        await Db.SaveChangesAsync();
         return JsonSerializer.Serialize(new { userProject.Project.Id, userProject.Project.Name, Status = "updated" });
     }
 
@@ -154,30 +147,30 @@ public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpConte
     public async Task<string> DeleteProject(
         [Description("The project ID to delete.")] Guid projectId)
     {
-        var userProject = await db.UserProjects
+        var userProject = await Db.UserProjects
             .Include(up => up.Project)
             .FirstOrDefaultAsync(up => up.UserId == UserId && up.ProjectId == projectId
                 && up.Role == ProjectRole.Owner);
 
         if (userProject == null)
-            return """{"error":"Project not found or you are not the owner"}""";
+            return McpErrors.ProjectNotFoundOrNotOwner;
 
-        db.Projects.Remove(userProject.Project);
-        await db.SaveChangesAsync();
-        return """{"status":"deleted"}""";
+        Db.Projects.Remove(userProject.Project);
+        await Db.SaveChangesAsync();
+        return McpErrors.Deleted;
     }
 
     [McpServerTool, Description("List all members of a project.")]
     public async Task<string> ListProjectMembers(
         [Description("The project ID.")] Guid projectId)
     {
-        var hasAccess = await db.UserProjects
+        var hasAccess = await Db.UserProjects
             .AnyAsync(up => up.UserId == UserId && up.ProjectId == projectId);
 
         if (!hasAccess)
-            return """{"error":"Project not found"}""";
+            return McpErrors.ProjectNotFound;
 
-        var members = await db.UserProjects
+        var members = await Db.UserProjects
             .Where(up => up.ProjectId == projectId)
             .Select(up => new
             {

--- a/src/Deckle.MCP/Tools/ProjectTools.cs
+++ b/src/Deckle.MCP/Tools/ProjectTools.cs
@@ -91,8 +91,8 @@ public sealed class ProjectTools(AppDbContext db, IHttpContextAccessor httpConte
             UpdatedAt = DateTime.UtcNow
         };
 
-        Db.Projects.Add(project);
-        Db.UserProjects.Add(new UserProject
+        await Db.Projects.AddAsync(project);
+        await Db.UserProjects.AddAsync(new UserProject
         {
             UserId = UserId,
             ProjectId = project.Id,

--- a/src/Deckle.Web/src/lib/api/apiKeys.ts
+++ b/src/Deckle.Web/src/lib/api/apiKeys.ts
@@ -1,0 +1,24 @@
+import { api } from './client';
+
+export interface ApiKey {
+	id: string;
+	name: string;
+	createdAt: string;
+	lastUsedAt: string | null;
+}
+
+export interface CreateApiKeyResponse {
+	id: string;
+	name: string;
+	key: string;
+	createdAt: string;
+}
+
+export const apiKeysApi = {
+	list: (fetchFn?: typeof fetch) => api.get<ApiKey[]>('/api-keys', undefined, fetchFn),
+
+	create: (name: string) =>
+		api.post<CreateApiKeyResponse>('/api-keys', { name }),
+
+	delete: (id: string) => api.delete<void>(`/api-keys/${id}`)
+};

--- a/src/Deckle.Web/src/lib/api/index.ts
+++ b/src/Deckle.Web/src/lib/api/index.ts
@@ -7,3 +7,4 @@ export * from './auth';
 export * from './files';
 export * from './admin';
 export * from './users';
+export * from './apiKeys';

--- a/src/Deckle.Web/src/lib/components/TopBar.svelte
+++ b/src/Deckle.Web/src/lib/components/TopBar.svelte
@@ -3,7 +3,7 @@
   import type { CurrentUser } from '$lib/types';
   import Avatar from './Avatar.svelte';
   import LogoMark from './LogoMark.svelte';
-  import { SettingsIcon, LogoutIcon, MenuIcon } from './icons';
+  import { SettingsIcon, LogoutIcon, MenuIcon, PlugIcon } from './icons';
   import { topbarProject } from '$lib/stores/topbarProject';
   import { topbarTabs } from '$lib/stores/topbarTabs';
   import { page } from '$app/stores';
@@ -132,6 +132,10 @@
               <a href="/account/settings" class="dropdown-item">
                 <SettingsIcon size={16} />
                 Account Settings
+              </a>
+              <a href="/account/mcp" class="dropdown-item">
+                <PlugIcon size={16} />
+                AI Agent Access
               </a>
               <button class="dropdown-item" onclick={handleSignOut}>
                 <LogoutIcon size={16} />

--- a/src/Deckle.Web/src/lib/components/icons/PlugIcon.svelte
+++ b/src/Deckle.Web/src/lib/components/icons/PlugIcon.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+  let { size = 20, class: className = '' }: { size?: number; class?: string } = $props();
+</script>
+
+<svg
+  viewBox="0 0 20 20"
+  width={size}
+  height={size}
+  fill="currentColor"
+  class={className}
+  aria-hidden="true"
+>
+  <path
+    fill-rule="evenodd"
+    d="M11.3 1.046A1 1 0 0112 2v5h1a1 1 0 110 2h-1v1a1 1 0 11-2 0V9H9v1a1 1 0 11-2 0V9H6a1 1 0 110-2h1V2a1 1 0 011.7-.714l.3.26.3-.26A1 1 0 0111.3 1.046zM6 12a1 1 0 01.707.293l.793.793V15a2 2 0 002 2h1a2 2 0 002-2v-1.914l.793-.793a1 1 0 011.414 1.414l-.793.793V15a4 4 0 01-4 4h-1a4 4 0 01-4-4v-1.5l-.793-.793A1 1 0 016 12z"
+    clip-rule="evenodd"
+  />
+</svg>

--- a/src/Deckle.Web/src/lib/components/icons/index.ts
+++ b/src/Deckle.Web/src/lib/components/icons/index.ts
@@ -18,6 +18,7 @@ export { default as LogoutIcon } from './LogoutIcon.svelte';
 export { default as MaximizeIcon } from './MaximizeIcon.svelte';
 export { default as MenuIcon } from './MenuIcon.svelte';
 export { default as MinimizeIcon } from './MinimizeIcon.svelte';
+export { default as PlugIcon } from './PlugIcon.svelte';
 export { default as PlusIcon } from './PlusIcon.svelte';
 export { default as SettingsIcon } from './SettingsIcon.svelte';
 export { default as TableIcon } from './TableIcon.svelte';

--- a/src/Deckle.Web/src/routes/(authenticated)/account/mcp/+page.server.ts
+++ b/src/Deckle.Web/src/routes/(authenticated)/account/mcp/+page.server.ts
@@ -1,0 +1,13 @@
+import { apiKeysApi } from '$lib/api';
+import { error } from '@sveltejs/kit';
+import type { PageServerLoad } from './$types';
+
+export const load: PageServerLoad = async ({ fetch }) => {
+	try {
+		const apiKeys = await apiKeysApi.list(fetch);
+		return { apiKeys };
+	} catch (err) {
+		console.error('Failed to load API keys:', err);
+		throw error(500, 'Failed to load API keys');
+	}
+};

--- a/src/Deckle.Web/src/routes/(authenticated)/account/mcp/+page.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/account/mcp/+page.svelte
@@ -1,0 +1,261 @@
+<script lang="ts">
+  import type { PageData } from './$types';
+  import { Card } from '$lib/components';
+  import PageHeader from '$lib/components/layout/PageHeader.svelte';
+  import ApiKeysCard from './_components/ApiKeysCard.svelte';
+
+  let { data }: { data: PageData } = $props();
+</script>
+
+<PageHeader>
+  <h1>AI Agent Access (MCP)</h1>
+</PageHeader>
+
+<div class="page-layout">
+  <!-- API Keys -->
+  <div class="section">
+    <h2>API Keys</h2>
+    <ApiKeysCard apiKeys={data.apiKeys} />
+  </div>
+
+  <!-- How to connect -->
+  <div class="section">
+    <h2>How to Connect</h2>
+    <Card>
+      <p class="prose">
+        Deckle exposes a <strong>Model Context Protocol (MCP)</strong> server that lets AI agents
+        like Claude create and manage your tabletop game projects. Connect any MCP-compatible
+        client using the details below.
+      </p>
+
+      <h3>1. Create an API key</h3>
+      <p class="prose">
+        Generate a key in the section above and copy it somewhere safe — it is only shown once.
+      </p>
+
+      <h3>2. Find the MCP server URL</h3>
+      <p class="prose">
+        The MCP server runs alongside the Deckle API. Your administrator can tell you the URL; it
+        follows the pattern:
+      </p>
+      <pre class="code-block">https://&lt;mcp-host&gt;/mcp</pre>
+
+      <h3>3. Configure Claude Desktop</h3>
+      <p class="prose">
+        Add this block to your <code>claude_desktop_config.json</code>:
+      </p>
+      <pre class="code-block">{`{
+  "mcpServers": {
+    "deckle": {
+      "type": "http",
+      "url": "https://<mcp-host>/mcp",
+      "headers": {
+        "X-API-Key": "<your-api-key>"
+      }
+    }
+  }
+}`}</pre>
+
+      <h3>4. Configure other MCP clients</h3>
+      <p class="prose">
+        Point any MCP-compatible client at the server URL and set the
+        <code>X-API-Key</code> request header to your API key.
+      </p>
+    </Card>
+  </div>
+
+  <!-- Available tools -->
+  <div class="section">
+    <h2>What Agents Can Do</h2>
+    <Card>
+      <p class="prose">
+        Once connected, an agent has access to the following tools. All operations are scoped to
+        your account — agents cannot access other users' projects.
+      </p>
+
+      <div class="tool-groups">
+        <div class="tool-group">
+          <h3>Projects</h3>
+          <ul class="tool-list">
+            <li><code>list_projects</code> — List all your projects</li>
+            <li><code>get_project</code> — Fetch a single project's details</li>
+            <li><code>create_project</code> — Create a new project</li>
+            <li><code>update_project</code> — Rename, re-describe, or change visibility</li>
+            <li><code>delete_project</code> — Permanently delete a project</li>
+            <li><code>list_project_members</code> — See who has access</li>
+          </ul>
+        </div>
+
+        <div class="tool-group">
+          <h3>Components</h3>
+          <ul class="tool-list">
+            <li><code>list_components</code> — List all components in a project</li>
+            <li><code>get_component</code> — Fetch component details</li>
+            <li><code>create_card</code> — Add a card component (choose from 11 preset sizes)</li>
+            <li><code>create_dice</code> — Add dice (D4 → D20, with style and colour)</li>
+            <li><code>create_game_board</code> — Add a game board (preset or custom dimensions)</li>
+            <li><code>create_player_mat</code> — Add a player mat</li>
+            <li><code>delete_component</code> — Remove a component</li>
+            <li><code>link_data_source</code> — Attach a data source to a component</li>
+          </ul>
+        </div>
+
+        <div class="tool-group">
+          <h3>Data Sources</h3>
+          <ul class="tool-list">
+            <li><code>list_data_sources</code> — List data sources in a project</li>
+            <li><code>get_data_source</code> — Fetch data source details</li>
+            <li>
+              <code>create_google_sheets_data_source</code> — Link a public Google Sheet
+            </li>
+            <li><code>sync_data_source_metadata</code> — Update headers and row count</li>
+            <li><code>delete_data_source</code> — Remove a data source</li>
+          </ul>
+        </div>
+
+        <div class="tool-group">
+          <h3>Files (read-only)</h3>
+          <ul class="tool-list">
+            <li><code>list_files</code> — Browse project assets, optionally filtered by tag</li>
+            <li><code>list_directories</code> — Browse the folder hierarchy</li>
+            <li><code>list_file_tags</code> — List all tags used in a project</li>
+          </ul>
+        </div>
+      </div>
+
+      <div class="not-supported">
+        <strong>Not available via MCP:</strong> design editing, file uploads, and authentication
+        flows. These require the visual editor or the web UI.
+      </div>
+    </Card>
+  </div>
+</div>
+
+<style>
+  .page-layout {
+    padding: var(--pad-content);
+    display: grid;
+    grid-template-columns: 1fr 2fr;
+    gap: 0 2rem;
+    align-items: start;
+  }
+
+  @media (max-width: 768px) {
+    .page-layout {
+      grid-template-columns: 1fr;
+    }
+  }
+
+  .section {
+    margin-bottom: 2.5rem;
+  }
+
+  .section h2 {
+    font-size: 1.25rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin-bottom: 1rem;
+  }
+
+  /* Card prose */
+  .prose {
+    margin: 0 0 1rem;
+    font-size: 0.9375rem;
+    color: var(--color-text-secondary);
+    line-height: 1.6;
+  }
+
+  .prose:last-child {
+    margin-bottom: 0;
+  }
+
+  .prose code,
+  .prose code {
+    font-family: monospace;
+    background: var(--color-bg-subtle, #f0f0f0);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+    font-size: 0.88em;
+  }
+
+  /* Headings inside Card */
+  :global(.section) h3 {
+    font-size: 1rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 1.25rem 0 0.5rem;
+  }
+
+  :global(.section) h3:first-of-type {
+    margin-top: 1rem;
+  }
+
+  .code-block {
+    background: #f8f8f6;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: 0.875rem 1rem;
+    font-family: monospace;
+    font-size: 0.8125rem;
+    line-height: 1.6;
+    overflow-x: auto;
+    white-space: pre;
+    margin: 0 0 1rem;
+    color: var(--color-text);
+  }
+
+  /* Tool list */
+  .tool-groups {
+    display: flex;
+    flex-direction: column;
+    gap: 0;
+  }
+
+  .tool-group h3 {
+    font-size: 0.9375rem;
+    font-weight: 600;
+    color: var(--color-text);
+    margin: 1.25rem 0 0.5rem;
+    padding-bottom: 0.25rem;
+    border-bottom: 1px solid var(--color-border);
+  }
+
+  .tool-group:first-child h3 {
+    margin-top: 0.5rem;
+  }
+
+  .tool-list {
+    margin: 0;
+    padding: 0;
+    list-style: none;
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .tool-list li {
+    font-size: 0.9rem;
+    color: var(--color-text-secondary);
+    line-height: 1.4;
+  }
+
+  .tool-list code {
+    font-family: monospace;
+    font-size: 0.85em;
+    background: var(--color-bg-subtle, #f0f0f0);
+    padding: 0.1em 0.35em;
+    border-radius: 3px;
+    color: var(--color-sage);
+    font-weight: 500;
+  }
+
+  .not-supported {
+    margin-top: 1.5rem;
+    padding: 0.75rem 1rem;
+    background: #f8f8f6;
+    border-radius: var(--radius-md);
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+  }
+</style>

--- a/src/Deckle.Web/src/routes/(authenticated)/account/mcp/_components/ApiKeysCard.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/account/mcp/_components/ApiKeysCard.svelte
@@ -1,0 +1,195 @@
+<script lang="ts">
+  import { Card, Button } from '$lib/components';
+  import { TrashIcon, PlusIcon } from '$lib/components/icons';
+  import { apiKeysApi, type ApiKey, ApiError } from '$lib/api';
+  import { invalidateAll } from '$app/navigation';
+  import CreateApiKeyDialog from './CreateApiKeyDialog.svelte';
+
+  let { apiKeys }: { apiKeys: ApiKey[] } = $props();
+
+  let localKeys = $state<ApiKey[]>([...apiKeys]);
+  let showCreate = $state(false);
+  let deletingId = $state<string | null>(null);
+  let deleteError = $state<string | null>(null);
+
+  function formatDate(iso: string) {
+    return new Date(iso).toLocaleDateString(undefined, {
+      year: 'numeric',
+      month: 'short',
+      day: 'numeric'
+    });
+  }
+
+  function handleCreated(key: ApiKey) {
+    localKeys = [...localKeys, key];
+  }
+
+  async function handleDelete(id: string) {
+    deletingId = id;
+    deleteError = null;
+    try {
+      await apiKeysApi.delete(id);
+      localKeys = localKeys.filter((k) => k.id !== id);
+    } catch (err) {
+      deleteError = err instanceof ApiError ? err.message : 'Failed to delete key';
+    } finally {
+      deletingId = null;
+    }
+  }
+</script>
+
+<Card>
+  <div class="header">
+    <p class="description">
+      API keys authenticate MCP clients. Each key grants full access to your projects on behalf of
+      your account — keep them secret.
+    </p>
+    <Button size="sm" onclick={() => (showCreate = true)}>
+      <PlusIcon size={14} />
+      New key
+    </Button>
+  </div>
+
+  {#if deleteError}
+    <p class="error">{deleteError}</p>
+  {/if}
+
+  {#if localKeys.length === 0}
+    <div class="empty">
+      <p>No API keys yet. Create one to connect an MCP client.</p>
+    </div>
+  {:else}
+    <table class="keys-table">
+      <thead>
+        <tr>
+          <th>Name</th>
+          <th>Created</th>
+          <th>Last used</th>
+          <th aria-label="Actions"></th>
+        </tr>
+      </thead>
+      <tbody>
+        {#each localKeys as key (key.id)}
+          <tr>
+            <td class="name-cell">{key.name}</td>
+            <td class="date-cell">{formatDate(key.createdAt)}</td>
+            <td class="date-cell">{key.lastUsedAt ? formatDate(key.lastUsedAt) : 'Never'}</td>
+            <td class="action-cell">
+              <button
+                class="delete-btn"
+                onclick={() => handleDelete(key.id)}
+                disabled={deletingId === key.id}
+                aria-label="Delete {key.name}"
+              >
+                <TrashIcon size={15} />
+              </button>
+            </td>
+          </tr>
+        {/each}
+      </tbody>
+    </table>
+  {/if}
+</Card>
+
+<CreateApiKeyDialog bind:show={showCreate} oncreated={handleCreated} />
+
+<style>
+  .header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 1rem;
+    margin-bottom: 1.25rem;
+  }
+
+  .description {
+    margin: 0;
+    font-size: 0.9375rem;
+    color: var(--color-text-secondary);
+    line-height: 1.5;
+    max-width: 44ch;
+  }
+
+  .error {
+    margin: 0 0 1rem;
+    font-size: 0.875rem;
+    color: var(--color-danger, #c0392b);
+  }
+
+  .empty {
+    padding: 2rem 0;
+    text-align: center;
+    color: var(--color-text-secondary);
+    font-size: 0.9375rem;
+  }
+
+  .empty p {
+    margin: 0;
+  }
+
+  .keys-table {
+    width: 100%;
+    border-collapse: collapse;
+    font-size: 0.9375rem;
+  }
+
+  .keys-table th {
+    text-align: left;
+    font-size: 0.8125rem;
+    font-weight: 600;
+    color: var(--color-text-secondary);
+    padding: 0 0 0.5rem;
+    border-bottom: 1px solid var(--color-border);
+    white-space: nowrap;
+  }
+
+  .keys-table td {
+    padding: 0.75rem 0;
+    border-bottom: 1px solid var(--color-border);
+    vertical-align: middle;
+  }
+
+  .keys-table tr:last-child td {
+    border-bottom: none;
+  }
+
+  .name-cell {
+    font-weight: 500;
+    color: var(--color-text);
+    word-break: break-word;
+  }
+
+  .date-cell {
+    color: var(--color-text-secondary);
+    white-space: nowrap;
+    padding-right: 1.5rem;
+  }
+
+  .action-cell {
+    text-align: right;
+    width: 2rem;
+  }
+
+  .delete-btn {
+    background: none;
+    border: none;
+    cursor: pointer;
+    color: var(--color-text-secondary);
+    padding: 0.25rem;
+    border-radius: 4px;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    transition: color 0.15s, background-color 0.15s;
+  }
+
+  .delete-btn:hover:not(:disabled) {
+    color: var(--color-danger, #c0392b);
+    background-color: rgba(192, 57, 43, 0.08);
+  }
+
+  .delete-btn:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+  }
+</style>

--- a/src/Deckle.Web/src/routes/(authenticated)/account/mcp/_components/CreateApiKeyDialog.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/account/mcp/_components/CreateApiKeyDialog.svelte
@@ -1,0 +1,232 @@
+<script lang="ts">
+  import { Dialog, Button } from '$lib/components';
+  import { apiKeysApi, type ApiKey, ApiError } from '$lib/api';
+
+  interface Props {
+    show: boolean;
+    oncreated: (key: ApiKey) => void;
+  }
+
+  let { show = $bindable(), oncreated }: Props = $props();
+
+  // Step 1: name input. Step 2: show generated key.
+  type Step = 'name' | 'reveal';
+  let step = $state<Step>('name');
+  let name = $state('');
+  let generatedKey = $state('');
+  let copied = $state(false);
+  let isSubmitting = $state(false);
+  let error = $state<string | undefined>(undefined);
+
+  $effect(() => {
+    if (!show) {
+      name = '';
+      generatedKey = '';
+      copied = false;
+      isSubmitting = false;
+      error = undefined;
+      step = 'name';
+    }
+  });
+
+  async function handleCreate() {
+    if (!name.trim()) {
+      error = 'Key name is required';
+      return;
+    }
+    error = undefined;
+    isSubmitting = true;
+    try {
+      const response = await apiKeysApi.create(name.trim());
+      generatedKey = response.key;
+      step = 'reveal';
+      oncreated({ id: response.id, name: response.name, createdAt: response.createdAt, lastUsedAt: null });
+    } catch (err) {
+      error = err instanceof ApiError ? err.message : 'Failed to create API key';
+    } finally {
+      isSubmitting = false;
+    }
+  }
+
+  async function copyKey() {
+    await navigator.clipboard.writeText(generatedKey);
+    copied = true;
+    setTimeout(() => (copied = false), 2000);
+  }
+
+  function handleDone() {
+    show = false;
+  }
+</script>
+
+<Dialog bind:show title={step === 'name' ? 'Create API Key' : 'API Key Created'} maxWidth="480px">
+  {#snippet children()}
+    {#if step === 'name'}
+      <p class="dialog-description">
+        Give this key a name so you can identify it later (e.g. "Claude Desktop").
+      </p>
+      <div class="field">
+        <label for="key-name">Key name</label>
+        <input
+          id="key-name"
+          type="text"
+          bind:value={name}
+          placeholder="e.g. Claude Desktop"
+          maxlength="255"
+          onkeydown={(e) => e.key === 'Enter' && handleCreate()}
+          disabled={isSubmitting}
+        />
+        {#if error}
+          <p class="field-error">{error}</p>
+        {/if}
+      </div>
+    {:else}
+      <div class="reveal-warning">
+        <span class="warning-icon">⚠</span>
+        Copy this key now — it will <strong>not</strong> be shown again.
+      </div>
+      <div class="key-display">
+        <code class="key-value">{generatedKey}</code>
+        <button class="copy-btn" onclick={copyKey}>
+          {copied ? '✓ Copied' : 'Copy'}
+        </button>
+      </div>
+      <p class="reveal-hint">
+        Add this as the <code>X-API-Key</code> header when connecting your MCP client.
+      </p>
+    {/if}
+  {/snippet}
+
+  {#snippet actions()}
+    {#if step === 'name'}
+      <Button variant="secondary" onclick={() => (show = false)} disabled={isSubmitting}>
+        Cancel
+      </Button>
+      <Button onclick={handleCreate} disabled={isSubmitting || !name.trim()}>
+        {isSubmitting ? 'Creating…' : 'Create'}
+      </Button>
+    {:else}
+      <Button onclick={handleDone}>Done</Button>
+    {/if}
+  {/snippet}
+</Dialog>
+
+<style>
+  .dialog-description {
+    margin: 0 0 1.25rem;
+    color: var(--color-text-secondary);
+    font-size: 0.9375rem;
+    line-height: 1.5;
+  }
+
+  .field {
+    display: flex;
+    flex-direction: column;
+    gap: 0.375rem;
+  }
+
+  .field label {
+    font-size: 0.875rem;
+    font-weight: 500;
+    color: var(--color-text);
+  }
+
+  .field input {
+    width: 100%;
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    font-size: 0.9375rem;
+    font-family: inherit;
+    color: var(--color-text);
+    background: var(--color-bg);
+    box-sizing: border-box;
+    transition: border-color 0.15s;
+  }
+
+  .field input:focus {
+    outline: none;
+    border-color: var(--color-sage);
+  }
+
+  .field input:disabled {
+    opacity: 0.6;
+    cursor: not-allowed;
+  }
+
+  .field-error {
+    font-size: 0.8125rem;
+    color: var(--color-danger, #c0392b);
+    margin: 0;
+  }
+
+  .reveal-warning {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: #fff8e1;
+    border: 1px solid #ffe082;
+    border-radius: var(--radius-md);
+    padding: 0.625rem 0.875rem;
+    font-size: 0.875rem;
+    color: #7a5800;
+    margin-bottom: 1rem;
+  }
+
+  .warning-icon {
+    font-size: 1rem;
+    flex-shrink: 0;
+  }
+
+  .key-display {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    background: var(--color-bg-subtle, #f5f5f5);
+    border: 1px solid var(--color-border);
+    border-radius: var(--radius-md);
+    padding: 0.625rem 0.75rem;
+    margin-bottom: 0.75rem;
+  }
+
+  .key-value {
+    flex: 1;
+    font-family: monospace;
+    font-size: 0.8125rem;
+    word-break: break-all;
+    color: var(--color-text);
+  }
+
+  .copy-btn {
+    flex-shrink: 0;
+    padding: 0.25rem 0.625rem;
+    background: var(--color-sage);
+    color: white;
+    border: none;
+    border-radius: var(--radius-sm, 4px);
+    font-size: 0.8125rem;
+    font-family: inherit;
+    cursor: pointer;
+    transition: opacity 0.15s;
+    white-space: nowrap;
+  }
+
+  .copy-btn:hover {
+    opacity: 0.85;
+  }
+
+  .reveal-hint {
+    font-size: 0.875rem;
+    color: var(--color-text-secondary);
+    margin: 0;
+    line-height: 1.5;
+  }
+
+  .reveal-hint code {
+    font-family: monospace;
+    background: var(--color-bg-subtle, #f0f0f0);
+    padding: 0.1em 0.3em;
+    border-radius: 3px;
+    font-size: 0.85em;
+  }
+</style>

--- a/src/Deckle.slnx
+++ b/src/Deckle.slnx
@@ -9,6 +9,9 @@
     <Project Path="Deckle.Email/Deckle.Email.csproj" />
     <Project Path="Deckle.Email.Abstractions/Deckle.Email.Abstractions.csproj" />
   </Folder>
+  <Folder Name="/Services/">
+    <Project Path="Deckle.MCP/Deckle.MCP.csproj" />
+  </Folder>
   <Folder Name="/Tests/">
     <Project Path="Deckle.API.Tests/Deckle.API.Tests.csproj" />
   </Folder>

--- a/src/Deckle.slnx
+++ b/src/Deckle.slnx
@@ -14,6 +14,7 @@
   </Folder>
   <Folder Name="/Tests/">
     <Project Path="Deckle.API.Tests/Deckle.API.Tests.csproj" />
+    <Project Path="Deckle.MCP.Tests/Deckle.MCP.Tests.csproj" />
   </Folder>
   <Project Path="Deckle.AppHost/Deckle.AppHost.csproj" />
   <Project Path="Deckle.ServiceDefaults/Deckle.ServiceDefaults.csproj" />


### PR DESCRIPTION
Introduces a Model Context Protocol server (Deckle.MCP) so AI agents
can create and manage tabletop game projects programmatically.

Key changes:
- ApiKey entity + migration: users generate named API keys via the web UI
  (POST /api-keys) to authenticate MCP clients
- Deckle.MCP project: standalone ASP.NET Core service using
  ModelContextProtocol.AspNetCore 1.3.0 with HTTP/SSE transport
- ApiKeyAuthenticationHandler: validates X-API-Key header against
  hashed keys stored in the database
- MCP tools: ProjectTools, ComponentTools, DataSourceTools, FileTools
  covering project CRUD, all component types, Google Sheets data sources,
  and file/directory browsing
- AppHost updated to register Deckle.MCP as an Aspire service
- Fix pre-existing test build failure in UserServiceTests (missing
  IPasswordHasher<User> constructor argument)

https://claude.ai/code/session_01DZn6C8hAmDip6Y8FZFvpcf