### PR TITLE
Add reduced-motion support and tokenize chrome corner radii

### DIFF
--- a/src/Deckle.Web/src/app.css
+++ b/src/Deckle.Web/src/app.css
@@ -50,9 +50,11 @@
   --scrollbar-track: rgba(0, 0, 0, 0.05);
   --scrollbar-thumb: rgba(120, 160, 131, 0.3);
   --scrollbar-thumb-hover: rgba(120, 160, 131, 0.5);
+  --radius-xs: 4px;
   --radius-sm: 6px;
   --radius-md: 8px;
   --radius-lg: 12px;
+  --radius-xl: 16px;
   --bg-light: var(--color-bg-primary);
   --bg-teal: linear-gradient(135deg, var(--color-teal-grey) 0%, var(--color-muted-teal) 100%);
   --pad-content: 2rem; /*todo: clamp for better responsiveness at smaller sizes*/
@@ -220,9 +222,27 @@ p {
 
 ::-webkit-scrollbar-thumb {
   background: var(--scrollbar-thumb);
-  border-radius: 4px;
+  border-radius: var(--radius-xs);
 }
 
 ::-webkit-scrollbar-thumb:hover {
   background: var(--scrollbar-thumb-hover);
+}
+
+/* ---- Reduced motion -------------------------------------------------------
+   Neutralize the app's decorative motion (the 0.2s transition motif and the
+   translateY hover-lift, which rides on those transitions) when the user asks
+   for reduced motion. Deliberately scoped to transitions only: looping
+   spinners are essential progress feedback, not vestibular-trigger motion, so
+   their @keyframes are left running. The one decorative keyframe animation
+   (dice-roll) and the JS/WAAPI shuffle are gated separately in JS via
+   prefersReducedMotion() — see lib/utils/reducedMotion.ts. */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    transition-duration: 0.01ms !important;
+    transition-delay: 0ms !important;
+    scroll-behavior: auto !important;
+  }
 }

--- a/src/Deckle.Web/src/lib/components/Badge.svelte
+++ b/src/Deckle.Web/src/lib/components/Badge.svelte
@@ -62,7 +62,7 @@
 
   /* Shape variants */
   .badge.pill {
-    border-radius: 12px;
+    border-radius: var(--radius-lg);
   }
 
   .badge.circle {

--- a/src/Deckle.Web/src/lib/components/Button.svelte
+++ b/src/Deckle.Web/src/lib/components/Button.svelte
@@ -73,19 +73,19 @@
   .btn.sm {
     padding: 0.5rem 1rem;
     font-size: 0.875rem;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
   }
 
   .btn.md {
     padding: 0.625rem 1.25rem;
     font-size: 0.9375rem;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
   }
 
   .btn.lg {
     padding: 0.75rem 1.5rem;
     font-size: 1rem;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
   }
 
   /* Primary variant */
@@ -142,7 +142,7 @@
   .btn.icon {
     background: none;
     padding: 0.25rem;
-    border-radius: 4px;
+    border-radius: var(--radius-xs);
     color: inherit;
   }
 

--- a/src/Deckle.Web/src/lib/components/DataTable.svelte
+++ b/src/Deckle.Web/src/lib/components/DataTable.svelte
@@ -140,7 +140,7 @@
   .data-table-container {
     overflow-x: auto;
     background-color: var(--color-surface);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     box-shadow: var(--shadow-sm);
   }
 

--- a/src/Deckle.Web/src/lib/components/DeleteConfirmationDialog.svelte
+++ b/src/Deckle.Web/src/lib/components/DeleteConfirmationDialog.svelte
@@ -101,7 +101,7 @@
     padding: 0.75rem;
     font-size: 0.875rem;
     border: 1px solid var(--color-border, #d1d5db);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     background: var(--color-background, white);
     color: var(--color-text, #333);
     font-family: inherit;
@@ -124,7 +124,7 @@
     font-size: 0.875rem;
     padding: 0.75rem;
     background-color: #ffebee;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     border: 1px solid #ef9a9a;
   }
 </style>

--- a/src/Deckle.Web/src/lib/components/Dialog.svelte
+++ b/src/Deckle.Web/src/lib/components/Dialog.svelte
@@ -84,7 +84,7 @@
 
   .dialog {
     background-color: var(--color-surface);
-    border-radius: 12px;
+    border-radius: var(--radius-lg);
     padding: var(--pad-content);
     width: 90%;
     max-height: 90vh;
@@ -113,7 +113,7 @@
     cursor: pointer;
     color: var(--color-accent-fg);
     padding: 0.25rem;
-    border-radius: 4px;
+    border-radius: var(--radius-xs);
     opacity: 0.6;
     transition: opacity 0.15s;
   }

--- a/src/Deckle.Web/src/lib/components/EditableText.svelte
+++ b/src/Deckle.Web/src/lib/components/EditableText.svelte
@@ -86,7 +86,7 @@
   .editable-text-input {
     padding: 0.125rem 0.25rem;
     border: 1px solid #0066cc;
-    border-radius: 3px;
+    border-radius: var(--radius-xs);
     background: white;
     outline: none;
     font-family: inherit;
@@ -106,6 +106,6 @@
 
   .editable-text-display:hover {
     background-color: rgba(0, 0, 0, 0.05);
-    border-radius: 3px;
+    border-radius: var(--radius-xs);
   }
 </style>

--- a/src/Deckle.Web/src/lib/components/LibraryRow.svelte
+++ b/src/Deckle.Web/src/lib/components/LibraryRow.svelte
@@ -345,7 +345,7 @@
     width: 1.125rem;
     height: 1.125rem;
     border: 2px solid var(--color-disabled-border);
-    border-radius: 4px;
+    border-radius: var(--radius-xs);
     display: flex;
     align-items: center;
     justify-content: center;

--- a/src/Deckle.Web/src/lib/components/SpreadsheetEditor.svelte
+++ b/src/Deckle.Web/src/lib/components/SpreadsheetEditor.svelte
@@ -166,7 +166,7 @@
     overflow-y: auto;
     max-height: 70vh;
     background-color: white;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
   }
 
@@ -279,7 +279,7 @@
     display: flex;
     align-items: center;
     justify-content: center;
-    border-radius: 4px;
+    border-radius: var(--radius-xs);
     padding: 0;
   }
 
@@ -333,7 +333,7 @@
     color: #6b7280;
     font-size: 0.8125rem;
     cursor: pointer;
-    border-radius: 0.375rem;
+    border-radius: var(--radius-sm);
     transition: all 0.2s;
   }
 

--- a/src/Deckle.Web/src/lib/components/TopBar.svelte
+++ b/src/Deckle.Web/src/lib/components/TopBar.svelte
@@ -183,7 +183,7 @@
     cursor: pointer;
     padding: 0.5rem;
     margin-right: 0.25rem;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     transition: background-color 0.2s ease;
   }
 
@@ -276,7 +276,7 @@
     gap: 0.75rem;
     cursor: pointer;
     padding: 0.5rem 0.75rem;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     transition: background-color 0.2s ease;
     background: none;
     border: none;
@@ -303,7 +303,7 @@
     padding: 0 0.125rem;
     line-height: 1;
     font-family: inherit;
-    border-radius: 4px;
+    border-radius: var(--radius-xs);
     transition: background-color 0.2s ease;
   }
 
@@ -321,7 +321,7 @@
     font-size: 0.875rem;
     font-weight: 500;
     padding: 0.5rem 0.75rem;
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     border: 1px solid var(--color-border);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     white-space: nowrap;
@@ -347,7 +347,7 @@
     min-width: 220px;
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     overflow: hidden;
     z-index: 89;
@@ -423,7 +423,7 @@
     color: white;
     cursor: pointer;
     padding: 0.5rem;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     transition: background-color 0.2s ease;
   }
 
@@ -438,7 +438,7 @@
     min-width: 180px;
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     box-shadow: 0 4px 12px rgba(0, 0, 0, 0.15);
     overflow: hidden;
     z-index: 89;

--- a/src/Deckle.Web/src/lib/components/componentForms/ComponentTypeSelector.svelte
+++ b/src/Deckle.Web/src/lib/components/componentForms/ComponentTypeSelector.svelte
@@ -39,7 +39,7 @@
   .type-card {
     background-color: var(--color-surface);
     border: 2px solid var(--color-secondary-fg);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     padding: 2rem 1.5rem;
     text-align: center;
     cursor: pointer;

--- a/src/Deckle.Web/src/lib/components/componentForms/DiceConfigForm.svelte
+++ b/src/Deckle.Web/src/lib/components/componentForms/DiceConfigForm.svelte
@@ -114,7 +114,7 @@
     width: 100%;
     aspect-ratio: 1;
     border: 3px solid transparent;
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     cursor: pointer;
     transition: all 0.2s ease;
     position: relative;

--- a/src/Deckle.Web/src/lib/components/forms/ColorInput.svelte
+++ b/src/Deckle.Web/src/lib/components/forms/ColorInput.svelte
@@ -28,7 +28,7 @@
     width: 50px;
     height: 36px;
     border: 1px solid #d1d5db;
-    border-radius: 4px;
+    border-radius: var(--radius-xs);
     cursor: pointer;
   }
 

--- a/src/Deckle.Web/src/lib/components/forms/NumberInput.svelte
+++ b/src/Deckle.Web/src/lib/components/forms/NumberInput.svelte
@@ -57,7 +57,7 @@
     line-height: 1.25rem;
     height: 2.125rem;
     border: 1px solid var(--color-border);
-    border-radius: 4px;
+    border-radius: var(--radius-xs);
     background: var(--color-surface);
     box-sizing: border-box;
     font-family: inherit;

--- a/src/Deckle.Web/src/lib/components/forms/TagInput.svelte
+++ b/src/Deckle.Web/src/lib/components/forms/TagInput.svelte
@@ -151,7 +151,7 @@
 		gap: 0.375rem;
 		padding: 0.375rem 0.5rem;
 		border: 1px solid var(--color-border);
-		border-radius: 0.25rem;
+		border-radius: var(--radius-xs);
 		min-height: 2.125rem;
 		background-color: var(--color-surface);
 	}
@@ -196,7 +196,7 @@
 		margin-top: 0.25rem;
 		background: var(--color-surface);
 		border: 1px solid var(--color-border);
-		border-radius: 0.25rem;
+		border-radius: var(--radius-xs);
 		max-height: 200px;
 		overflow-y: auto;
 		z-index: 1000;

--- a/src/Deckle.Web/src/lib/components/forms/base-input.css
+++ b/src/Deckle.Web/src/lib/components/forms/base-input.css
@@ -2,7 +2,7 @@
   width: 100%;
   padding: 0.5rem;
   border: 2px solid var(--color-teal-grey-light);
-  border-radius: 8px;
+  border-radius: var(--radius-md);
   font-family: inherit;
   font-size: 1rem;
   transition: border-color 0.2s ease;

--- a/src/Deckle.Web/src/lib/utils/reducedMotion.ts
+++ b/src/Deckle.Web/src/lib/utils/reducedMotion.ts
@@ -1,0 +1,16 @@
+/**
+ * Whether the user has requested reduced motion.
+ *
+ * CSS `@media (prefers-reduced-motion: reduce)` (see app.css) handles the
+ * declarative transition/animation motion, but JS-driven motion — the WAAPI
+ * shuffle and the JS-gated dice roll in the tabletop — can't be reached by CSS
+ * and must check this at runtime. SSR-safe: returns false when there is no
+ * `window` (server render), so animations only ever start on the client.
+ */
+export function prefersReducedMotion(): boolean {
+  return (
+    typeof window !== 'undefined' &&
+    typeof window.matchMedia === 'function' &&
+    window.matchMedia('(prefers-reduced-motion: reduce)').matches
+  );
+}

--- a/src/Deckle.Web/src/routes/(authenticated)/account/mcp/+page.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/account/mcp/+page.svelte
@@ -174,7 +174,7 @@
     font-family: monospace;
     background: var(--color-bg-subtle, #f0f0f0);
     padding: 0.1em 0.3em;
-    border-radius: 3px;
+    border-radius: var(--radius-xs);
     font-size: 0.88em;
   }
 
@@ -244,7 +244,7 @@
     font-size: 0.85em;
     background: var(--color-bg-subtle, #f0f0f0);
     padding: 0.1em 0.35em;
-    border-radius: 3px;
+    border-radius: var(--radius-xs);
     color: var(--color-accent-fg);
     font-weight: 500;
   }

--- a/src/Deckle.Web/src/routes/(authenticated)/account/mcp/_components/ApiKeysCard.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/account/mcp/_components/ApiKeysCard.svelte
@@ -176,7 +176,7 @@
     cursor: pointer;
     color: var(--color-text-secondary);
     padding: 0.25rem;
-    border-radius: 4px;
+    border-radius: var(--radius-xs);
     display: inline-flex;
     align-items: center;
     justify-content: center;

--- a/src/Deckle.Web/src/routes/(authenticated)/account/mcp/_components/CreateApiKeyDialog.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/account/mcp/_components/CreateApiKeyDialog.svelte
@@ -226,7 +226,7 @@
     font-family: monospace;
     background: var(--color-bg-subtle, #f0f0f0);
     padding: 0.1em 0.3em;
-    border-radius: 3px;
+    border-radius: var(--radius-xs);
     font-size: 0.85em;
   }
 </style>

--- a/src/Deckle.Web/src/routes/(authenticated)/account/settings/_components/PublicProfileCard.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/account/settings/_components/PublicProfileCard.svelte
@@ -232,7 +232,7 @@
     color: var(--color-text);
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     resize: vertical;
     line-height: 1.6;
   }
@@ -247,7 +247,7 @@
     padding: 0.625rem 0.875rem;
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     font-size: 0.9375rem;
     color: var(--color-text);
     line-height: 1.6;
@@ -292,7 +292,7 @@
     color: var(--color-text);
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     min-width: 0;
   }
 
@@ -319,7 +319,7 @@
     justify-content: center;
     background: none;
     border: 1px solid rgba(220, 38, 38, 0.3);
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     color: var(--color-danger-fg);
     font-size: 1.125rem;
     cursor: pointer;

--- a/src/Deckle.Web/src/routes/(authenticated)/account/setup/+page.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/account/setup/+page.svelte
@@ -233,7 +233,7 @@
 
   .setup-card {
     background: white;
-    border-radius: 16px;
+    border-radius: var(--radius-xl);
     padding: 3rem;
     max-width: 480px;
     width: 100%;

--- a/src/Deckle.Web/src/routes/(authenticated)/projects/+page.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/projects/+page.svelte
@@ -233,7 +233,7 @@
     padding: 0.75rem 1rem;
     background-color: var(--color-danger-bg);
     border: 1px solid var(--color-danger-border);
-    border-radius: 6px;
+    border-radius: var(--radius-sm);
     color: var(--color-danger-fg);
     font-size: 0.875rem;
     margin-top: 0.5rem;
@@ -247,7 +247,7 @@
     color: var(--color-text);
     background-color: var(--color-surface);
     border: 1px solid var(--color-border);
-    border-radius: 8px;
+    border-radius: var(--radius-md);
     cursor: pointer;
   }
 

--- a/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/tabletop/_components/DiceView.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/tabletop/_components/DiceView.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
   import type { DiceComponent } from '$lib/types';
+  import { prefersReducedMotion } from '$lib/utils/reducedMotion';
   import { untrack } from 'svelte';
 
   let { component, currentValue }: { component: DiceComponent; currentValue?: number } = $props();
@@ -58,6 +59,14 @@
     }
 
     if (target === undefined) return;
+
+    // Reduced motion: settle on the result immediately — no tumble, no
+    // random intermediate frames.
+    if (prefersReducedMotion()) {
+      animatedValue = target;
+      isRolling = false;
+      return;
+    }
 
     isRolling = true;
 

--- a/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/tabletop/_components/ShuffleAnimation.svelte
+++ b/src/Deckle.Web/src/routes/(authenticated)/projects/[username]/[projectCode]/tabletop/_components/ShuffleAnimation.svelte
@@ -2,6 +2,7 @@
   import type { Entity } from '$lib/tabletop';
   import { getTabletopApi } from '$lib/tabletop';
   import { getTemplateDisplaySize } from '$lib/tabletop/initialization';
+  import { prefersReducedMotion } from '$lib/utils/reducedMotion';
   import { onMount } from 'svelte';
   import EntityView from './EntityView.svelte';
 
@@ -37,6 +38,15 @@
   onMount(() => {
     const N = cardEls.length;
     if (N === 0) {
+      onComplete();
+      return;
+    }
+
+    // Reduced motion: skip the fan-out animation entirely. Apply the final
+    // z-index order (new top card on top) synchronously and complete now, so
+    // the deck lands in exactly the same state without any movement.
+    if (prefersReducedMotion()) {
+      zIndices = cards.map((_, i) => N - 1 - i);
       onComplete();
       return;
     }

--- a/src/Deckle.Web/src/routes/+page.svelte
+++ b/src/Deckle.Web/src/routes/+page.svelte
@@ -221,7 +221,7 @@
 
   .auth-card {
     background: var(--color-surface);
-    border-radius: 16px;
+    border-radius: var(--radius-xl);
     padding: 2rem;
     box-shadow: var(--shadow-lg);
     text-align: left;


### PR DESCRIPTION
Two P2 polish items from the taste-skill design audit, shipped together.

## 1. Reduced-motion support
- Global `@media (prefers-reduced-motion: reduce)` block in `app.css` that neutralizes **transitions only** — the `transition: all 0.2s ease` motif and the `translateY(-2px)` hover-lift, app-wide.
- **Spinners are deliberately exempt**: the block never touches `animation`, so looping `@keyframes spin` progress indicators keep spinning (essential feedback, not vestibular-trigger motion). The shared `LoadingSpinner` uses SVG SMIL and is unaffected regardless.
- JS/WAAPI motion that CSS can't reach is gated via a new SSR-safe `lib/utils/reducedMotion.ts` (`prefersReducedMotion()`):
  - `ShuffleAnimation.svelte` — skips the fan-out, applies the final z-order synchronously, completes.
  - `DiceView.svelte` — settles on the result immediately (no tumble, no random intermediate frames).
  - `EntityWrapper.svelte` flip is a CSS transition, so the global block handles it automatically.

## 2. Corner-radius tokenization (chrome scope)
- Extends the scale to `--radius-xs: 4px` … `--radius-xl: 16px` (`xs 4 / sm 6 / md 8 / lg 12 / xl 16`).
- Off-scale `16px` auth/setup cards **retained** as `--radius-xl` (no visual change); assorted `3px` clamp to `--radius-xs` (+1px, negligible).
- Routes every hard-coded `border-radius` in **app chrome** through a token: shared primitives, scrollbar thumb, auth landing, and the account (setup/MCP/settings) + projects dashboard.
- **Left untouched by design:** `border-radius: 50%` circles and pill/`999px` values; sub-4px micro-handles; the editor's card-design radii (`lib/components/editor/`, `--border-radius-component/-safe/-bleed`); and the deep feature-page bodies (admin, tabletop, export, data-sources, image-library) — the tracked follow-up.

## Testing
- `cd src/Deckle.Web && npm run check` → **0 errors** (89 pre-existing warnings).
- Reduced-motion verified via headless Chromium with `reducedMotion: 'reduce'` emulated: transition-duration collapses to `1e-05s` under reduce and stays `0.2s` otherwise, with spinners still animating; 0 page errors.
- Radius: diff review confirms value-preserving token swaps; landing page visually verified.

IA / routes / content unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01PCS7QUNH7cnz2xmobwoB5y

---
_Generated by [Claude Code](https://claude.ai/code/session_01PCS7QUNH7cnz2xmobwoB5y)_